### PR TITLE
Fix cli visualize command issues

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -598,8 +598,8 @@ def visualize(pickle_dir):
         time.sleep(1)
 
     params_opt = pickle.load(open(path_init,'rb'))
-    params_opt['remote'] = False
-    visualizer = Visualizer(**params_opt)   # create a visualizer that display/save images and plots
+    params_opt.remote = False
+    visualizer = Visualizer(params_opt)   # create a visualizer that display/save images and plots
 
     paths_plot = {'display_current_results':os.path.join(pickle_dir,'display_current_results.pickle'),
                 'plot_current_losses':os.path.join(pickle_dir,'plot_current_losses.pickle')}

--- a/cli.py
+++ b/cli.py
@@ -19,6 +19,7 @@ import torch.distributed as dist
 from packaging import version
 import subprocess
 import sys
+import pickle
 
 
 def set_seed(seed=0,rank=None):
@@ -586,6 +587,13 @@ def prepare_testing_data(input_dir, dataset_dir):
             image = cv2.resize(cv2.imread(os.path.join(input_dir, img)), (512, 512))
             cv2.imwrite(os.path.join(test_dir, img), np.concatenate([image, image, image, image, image, image], 1))
 
+# to load pickle file saved from gpu in a cpu environment: https://github.com/pytorch/pytorch/issues/16797#issuecomment-633423219
+from io import BytesIO
+class CPU_Unpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        if module == 'torch.storage' and name == '_load_from_bytes':
+            return lambda b: torch.load(BytesIO(b), map_location='cpu')
+        else: return super().find_class(module, name)
 
 @cli.command()
 @click.option('--pickle-dir', required=True, help='directory where the pickled snapshots are stored')
@@ -611,7 +619,7 @@ def visualize(pickle_dir):
             try:
                 last_modified_time_plot = os.path.getmtime(path_plot)
                 if last_modified_time_plot > last_modified_time[method]:
-                    params_plot = pickle.load(open(path_plot,'rb'))
+                    params_plot = CPU_Unpickler(open(path_plot,'rb')).load()
                     last_modified_time[method] = last_modified_time_plot
                     getattr(visualizer,method)(**params_plot)
                     print(f'{method} refreshed, last modified time {time.ctime(last_modified_time[method])}')


### PR DESCRIPTION
Two issues:
1. the visualize command still expected the old styled collection of input parameters which is no longer used with the options class - adapted to the new style
2. found that the pickle files created in a gpu environment can't be loaded in a cpu environment (e.g., training runs on a remote gpu environment and the user wants to track training progress in a visdom visualizer running in local cpu environment) - fixed that, now it works
  - the new pickle load method always uses cpu, no matter the environment you run visdom has gpu or not
  - this also helps to eliminate the unnecessary usage of gpu memory when it comes to plots in visdom when using the remote mode

