### PR TITLE
Fix two errors in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Use nvidia/cuda image
 FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04
 
+RUN rm /etc/apt/sources.list.d/cuda.list
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list
+
 RUN apt-get update -y && \
     apt-get install -y \
     gcc git wget \
@@ -13,5 +16,6 @@ RUN wget https://bootstrap.pypa.io/get-pip.py && python3.8 get-pip.py
 COPY cli.py cli.py
 COPY deepliif deepliif
 COPY setup.py setup.py
+COPY README.md README.md
 
 RUN pip install .


### PR DESCRIPTION
First error is from Ubuntu cuda GPG error "public key is not available": https://github.com/NVIDIA/nvidia-docker/issues/1632#issuecomment-1112667716.
Second error is from setup.py requiring README.md but current Dockerfile does not copy README.md into the docker image.