### PR TITLE
Stabilize Inference Results 

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -532,7 +532,10 @@ def serialize(models_dir, output_dir, device, verbose):
         print(name,':')
         model_original = models_original[name].cuda().eval() if device=='gpu' else models_original[name].cpu().eval()
         model_serialized = models_serialized[name].cuda() if device=='gpu' else models_serialized[name].cpu().eval()
-        test_diff_original_serialized(model_original,model_serialized,sample,verbose)
+        if name.startswith('GS'):
+            test_diff_original_serialized(model_original,model_serialized,torch.cat([sample, sample, sample], 1),verbose)
+        else:
+            test_diff_original_serialized(model_original,model_serialized,sample,verbose)
         print('PASS')
 
 

--- a/cli.py
+++ b/cli.py
@@ -11,7 +11,7 @@ from PIL import Image
 
 from deepliif.data import create_dataset, transform
 from deepliif.models import inference, postprocess, compute_overlap, init_nets, DeepLIIFModel, infer_modalities, infer_results_for_wsi
-from deepliif.util import allowed_file, Visualizer, read_input_image, get_information
+from deepliif.util import allowed_file, Visualizer, read_input_image, get_information, test_diff_original_serialized, disable_batchnorm_tracking_stats
 from deepliif.util.util import mkdirs, check_multi_scale
 # from deepliif.util import infer_results_for_wsi
 
@@ -478,14 +478,35 @@ def trainlaunch(**kwargs):
 @cli.command()
 @click.option('--models-dir', default='./model-server/DeepLIIF_Latest_Model', help='reads models from here')
 @click.option('--output-dir', help='saves results here.')
-def serialize(models_dir, output_dir):
+@click.option('--device', default='cpu', type=str, help='device to load model, either cpu or gpu')
+@click.option('--verbose', default=0, type=int,help='saves results here.')
+def serialize(models_dir, output_dir, device, verbose):
     """Serialize DeepLIIF models using Torchscript
     """
+    if output_dir is not None and output_dir != models_dir:
+        if not os.path.exists(output_dir):
+            print(f'creating output dir {output_dir}')
+            os.makedirs(output_dir)
+    
     output_dir = output_dir or models_dir
+    
     if os.path.exists(os.path.join(models_dir, 'train_opt.txt')):
         shutil.copy2(os.path.join(models_dir, 'train_opt.txt'), os.path.join(output_dir, 'train_opt.txt'))
 
     sample = transform(Image.new('RGB', (512, 512)))
+    
+    for name, net in init_nets(models_dir, eager_mode=True).items():
+        # the model should be in eval model so that there won't be randomness in tracking brought by dropout etc. layers
+        # https://github.com/pytorch/pytorch/issues/23999#issuecomment-747832122
+        net = net.eval()
+        net = disable_batchnorm_tracking_stats(net)
+        net = net.cpu()
+        if name.startswith('GS'):
+            traced_net = torch.jit.trace(net, torch.cat([sample, sample, sample], 1))
+        else:
+            traced_net = torch.jit.trace(net, sample)
+            # traced_net = torch.jit.script(net)
+        traced_net.save(f'{output_dir}/{name}.pt')
 
     with click.progressbar(
             init_nets(models_dir, eager_mode=True).items(),
@@ -498,8 +519,24 @@ def serialize(models_dir, output_dir):
             else:
                 traced_net = torch.jit.trace(net, sample)
             traced_net.save(f'{output_dir}/{name}.pt')
-         
+    
+    # test: whether the original and the serialized model produces highly similar predictions
+    print('testing similarity between prediction from original vs serialized models...')
+    models_original = init_nets(models_dir,eager_mode=True)
+    models_serialized = init_nets(output_dir,eager_mode=False)
+    if device == 'gpu':
+        sample = sample.cuda()
+    else:
+        sample = sample.cpu()
+    for name in models_serialized.keys():
+        print(name,':')
+        model_original = models_original[name].cuda().eval() if device=='gpu' else models_original[name].cpu().eval()
+        model_serialized = models_serialized[name].cuda() if device=='gpu' else models_serialized[name].cpu().eval()
+        test_diff_original_serialized(model_original,model_serialized,sample,verbose)
+        print('PASS')
 
+
+    
 @cli.command()
 @click.option('--input-dir', default='./Sample_Large_Tissues/', help='reads images from here')
 @click.option('--output-dir', help='saves results here.')
@@ -508,7 +545,8 @@ def serialize(models_dir, output_dir):
 @click.option('--region-size', default=20000, help='Due to limits in the resources, the whole slide image cannot be processed in whole.'
                                                    'So the WSI image is read region by region. '
                                                    'This parameter specifies the size each region to be read into GPU for inferrence.')
-def test(input_dir, output_dir, tile_size, model_dir, region_size):
+@click.option('--eager-mode', is_flag=True, help='use eager mode (loading original models, otherwise serialized ones)')
+def test(input_dir, output_dir, tile_size, model_dir, region_size, eager_mode):
     
     """Test trained models
     """
@@ -534,7 +572,8 @@ def test(input_dir, output_dir, tile_size, model_dir, region_size):
                     img,
                     tile_size=tile_size,
                     overlap_size=compute_overlap(img.size, tile_size),
-                    model_path=model_dir
+                    model_path=model_dir,
+                    eager_mode=eager_mode
                 )
 
                 post_images, scoring = postprocess(img, images)

--- a/deepliif/models/base_model.py
+++ b/deepliif/models/base_model.py
@@ -3,7 +3,7 @@ import torch
 from collections import OrderedDict
 from abc import ABC, abstractmethod
 from . import networks
-
+from ..util import disable_batchnorm_tracking_stats
 
 class BaseModel(ABC):
     """This class is an abstract base class (ABC) for models.
@@ -90,6 +90,7 @@ class BaseModel(ABC):
             if isinstance(name, str):
                 net = getattr(self, 'net' + name.split('_')[0])[int(name.split('_')[-1]) - 1]
                 net.eval()
+                net = disable_batchnorm_tracking_stats(net)
 
     def test(self):
         """Forward function used in test time.

--- a/deepliif/util/__init__.py
+++ b/deepliif/util/__init__.py
@@ -389,3 +389,41 @@ def read_results_from_pickle_file(input_addr):
     results = pickle.load(pickle_obj)
     pickle_obj.close()
     return results
+
+
+def test_diff_original_serialized(model_original,model_serialized,example,verbose=0):
+    threshold = 10
+    
+    orig_res = model_original(example)
+    if verbose > 0:
+        print('Original:')
+        print(orig_res.shape)
+        print(orig_res[0, 0:10])
+        print('min abs value:{}'.format(torch.min(torch.abs(orig_res))))
+
+    ts_res = model_serialized(example)
+    if verbose > 0:
+        print('Torchscript:')
+        print(ts_res.shape)
+        print(ts_res[0, 0:10])
+        print('min abs value:{}'.format(torch.min(torch.abs(ts_res))))
+    
+    abs_diff = torch.abs(orig_res-ts_res)
+    if verbose > 0:
+        print('Dif sum:')
+        print(torch.sum(abs_diff))
+        print('max dif:{}'.format(torch.max(abs_diff)))
+    
+    assert torch.sum(abs_diff) <= threshold, f"Sum of difference in predicted values {torch.sum(abs_diff)} is larger than threshold {threshold}"
+    
+def disable_batchnorm_tracking_stats(model):
+    # https://discuss.pytorch.org/t/performance-highly-degraded-when-eval-is-activated-in-the-test-phase/3323/16
+    # https://discuss.pytorch.org/t/performance-highly-degraded-when-eval-is-activated-in-the-test-phase/3323/67
+    # https://github.com/pytorch/pytorch/blob/ca39c5b04e30a67512589cafbd9d063cc17168a5/torch/nn/modules/batchnorm.py#L158
+    for m in model.modules():
+        for child in m.children():
+            if type(child) == torch.nn.BatchNorm2d:
+                child.track_running_stats = False
+                child.running_mean = None
+                child.running_var = None
+    return model

--- a/test.py
+++ b/test.py
@@ -55,8 +55,9 @@ if __name__ == '__main__':
     # test with eval mode. This only affects layers like batchnorm and dropout.
     # For [pix2pix]: we use batchnorm and dropout in the original pix2pix. You can experiment it with and without eval() mode.
     # For [CycleGAN]: It should not affect CycleGAN as CycleGAN uses instancenorm without dropout.
-    if opt.eval:
-        model.eval()
+    model.eval()
+    # if opt.eval:
+    #     #model.eval()
 
     _start_time = time.time()
 


### PR DESCRIPTION
This PR involves 3 aspects of work:
1. a more suitable `eval()` mode for DeepLIIF model
  - introduced function `disable_batchnorm_tracking_stats` in `deepliif/utils/__init__.py`: force `eval()` mode to use statistics calculated based on the input image(s) for normalization, instead of using running mean/variance collected during training
2. modified model serialization command to use the `eval()` mode
3. some other enhancements
  - implemented a small test `test_diff_original_serialized` to check if the predicted values of the same image from the original model files vs the serialized model files are close enough
  - added this small test `test_diff_original_serialized` to `cli.py serialize`
  - implemented flag `--eager-mode` in `cli.py test` command: this makes potential switch of inference method easier and as a result allows easier testing of model prediction similarity across inference methods & easier switch in production environment
  - create output directory in serialize command if not exists

## Summary
When it comes to comparisons between predicted values produced by different methods, we are actually looking at:
||model files|command|
|-|-|-|
|1|original files|python test.py|
|2|original files|python cli.py test --eager-mode|
|3|serialized files|python cli.py test|

Method 1 and method 2 should always yield identical results. Method 3, ideally, should yield as similar results as the previous 2 methods as possible, if not a perfect match, given the fact that the serialization process could unfortunately lose some information.

Using image `GADIDX_0_14336_1_1`:
|method|method|avg diff in predicted values per pixel - before this PR|avg diff in predicted values per pixel - after this PR|note|
|-|-|-|-|-|
|2|1|-0.0269|0.0027|if we look at mod2 only, it goes from -0.1287 (overall much darker) to 0.0338 (overall somewhat brighter)|
|3|2|2.2065e-06|-2.6512e-07|it is on a small magnitude, small enough to be ignored|

* Difference in pixels is preferred over absolute difference because visually the brighter and darker pixels could cancel out to some extent, so arguably it could be closer to human perception in our case. Also, the sign could possibly tell if overall one image is perceived darker or brighter as compared to the other. I'd be happy to try any other metrics.
* There are a few more metrics listed in the notebook output attached.

In addition, for any two runs using the same command, the produced images should be identical regardless of the command.

Using image `GADIDX_0_14336_1_1`:
||model files|command|reproducible predictions - before this PR|reproducible predictions - after this PR|
|-|-|-|-|-|
|1|original files|python test.py|**N**|Y|
|2|original files|python cli.py test --eager-mode|Y|Y|
|3|serialized files|python cli.py test|Y|Y|

Attachments:
[notebooks.zip](https://github.com/nadeemlab/DeepLIIF/files/10329769/notebooks.zip): this includes both the notebooks and the script needed to perform image comparison; uncompress them under the DeepLIIF folder and replace the directories in the notebooks with your own to run them

----
### 1. `eval()` vs `train()` mode for DeepLIIF
The main differences between `eval()` and `train()` mode in DeepLIIF model that affects predicted values come from
a. the batchnorm layers
b. the dropout layers

For batchnorm layers, at training time it calculates mean/variance within the current batch of data and applies this **batch-wise** statistics onto each data point from the current batch while updating the running mean/variance it keeps. At evaluation time, it applies the **running mean/variance** to the input data instead.

DeepLIIF model is typically trained on very small batch size of data, say 1 or 2. This I believe effectively **drives the model to adapt the parameters to "input" tensors normalized on their own mean/variance**, or a mean/variance that is largely impacted by their own values. It would not be a surprise that the model's inference (`eval()` mode on) produces much worse predicted values as at this time the tensors are normalized using the running mean/variance collected across possibly hundreds or thousands of training images.

Forcing batchnorm layers in `eval()` mode to ignore the collected stats but calculating it for the input image significantly mitigates the low-accuracy inference issue.

A function `disable_batchnorm_tracking_stats` is added to the module and is called when the DeepLIIF model is loaded for evaluation, to set the preferred behavior of the batchnorm layers.

### 2. warning messages in serialization method
Torchscript serialization is a preferred step, in the source code, before the test command can be called. This however produces a lot of warning messages that complain about mismatched elements.

Essentially, a random input tensor is created and passed over to the loaded model for a forward pass. The `jit.trace()` method records the activated operations to form the serialized model.

There can be randomness if the model is in `train()` mode. For example, if the model has dropout layers, a random section of elements in the output tensor after the dropout operation will be zeroed out. Every time one runs this forward pass, the elements zeroed out will very likely be different. `jit.trace()` will mistakenly learn this operation once and add it as part of the serialized model. This is what caused the serialization method to throw warning messages, and why running `test.py` twice would generate results that are not identical.

This is fixed by setting the model to the `eval()` mode before calling `jit.trace()`.