### PR TITLE
Improved Training Opts Loading in test.py and Stable Inference

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -516,7 +516,7 @@ def serialize(models_dir, output_dir, device, verbose):
 @click.option('--region-size', default=20000, help='Due to limits in the resources, the whole slide image cannot be processed in whole.'
                                                    'So the WSI image is read region by region. '
                                                    'This parameter specifies the size each region to be read into GPU for inferrence.')
-@click.option('--eager-mode', is_flag=True, help='use eager mode (loading original models, otherwise serialized ones')
+@click.option('--eager-mode', is_flag=True, help='use eager mode (loading original models, otherwise serialized ones)')
 @click.option('--color-dapi', is_flag=True, help='color dapi image to produce the same coloring as in the paper')
 @click.option('--color-marker', is_flag=True, help='color marker image to produce the same coloring as in the paper')
 def test(input_dir, output_dir, tile_size, model_dir, region_size, eager_mode,

--- a/cli.py
+++ b/cli.py
@@ -486,7 +486,8 @@ def serialize(models_dir, output_dir):
 @click.option('--region-size', default=20000, help='Due to limits in the resources, the whole slide image cannot be processed in whole.'
                                                    'So the WSI image is read region by region. '
                                                    'This parameter specifies the size each region to be read into GPU for inferrence.')
-def test(input_dir, output_dir, tile_size, model_dir, region_size):
+@click.option('--eager-mode', is_flag=True, help='use eager mode (loading original models, otherwise serialized ones)')
+def test(input_dir, output_dir, tile_size, model_dir, region_size, eager_mode):
     
     """Test trained models
     """
@@ -507,7 +508,7 @@ def test(input_dir, output_dir, tile_size, model_dir, region_size):
                 print(time.time() - start_time)
             else:
                 img = Image.open(os.path.join(input_dir, filename)).convert('RGB')
-                images, scoring = infer_modalities(img, tile_size, model_dir)
+                images, scoring = infer_modalities(img, tile_size, model_dir, eager_mode)
 
                 for name, i in images.items():
                     i.save(os.path.join(

--- a/deepliif/models/__init__.py
+++ b/deepliif/models/__init__.py
@@ -88,7 +88,10 @@ def create_model(opt):
 
 
 def load_torchscript_model(model_pt_path, device):
-    return torch.jit.load(model_pt_path, map_location=device)
+    net = torch.jit.load(model_pt_path, map_location=device)
+    net = disable_batchnorm_tracking_stats(net)
+    net.eval()
+    return net
 
 
 def read_model_params(file_addr):
@@ -132,7 +135,8 @@ def load_eager_models(model_dir, devices):
             os.path.join(model_dir, f'latest_net_{n}.pth'),
             map_location=devices[n]
         ))
-        nets[n] = net
+        nets[n] = disable_batchnorm_tracking_stats(net)
+        nets[n].eval()
 
     for n in ['G51', 'G52', 'G53', 'G54', 'G55']:
         net = UnetGenerator(input_nc, output_nc, 9, ngf, norm_layer=norm_layer, use_dropout=use_dropout)
@@ -140,7 +144,8 @@ def load_eager_models(model_dir, devices):
             os.path.join(model_dir, f'latest_net_{n}.pth'),
             map_location=devices[n]
         ))
-        nets[n] = net
+        nets[n] = disable_batchnorm_tracking_stats(net)
+        nets[n].eval()
 
     return nets
 
@@ -255,7 +260,8 @@ def run_wrapper(tile, run_fn, model_path, eager_mode=False):
         return run_fn(tile, model_path, eager_mode)
 
 
-def inference(img, tile_size, overlap_size, model_path, use_torchserve=False, eager_mode=False):
+def inference(img, tile_size, overlap_size, model_path, use_torchserve=False, eager_mode=False,
+              color_dapi=False, color_marker=False):
 
     
     tiles = list(generate_tiles(img, tile_size, overlap_size))
@@ -281,12 +287,14 @@ def inference(img, tile_size, overlap_size, model_path, use_torchserve=False, ea
 
     images['DAPI'] = stitch(get_net_tiles('G2'), tile_size, overlap_size).resize(img.size)
     dapi_pix = np.array(images['DAPI'].convert('L').convert('RGB'))
-    dapi_pix[:, :, 0] = 0
+    if color_dapi:
+      dapi_pix[:, :, 0] = 0
     images['DAPI'] = Image.fromarray(dapi_pix)
     images['Lap2'] = stitch(get_net_tiles('G3'), tile_size, overlap_size).resize(img.size)
     images['Marker'] = stitch(get_net_tiles('G4'), tile_size, overlap_size).resize(img.size)
     marker_pix = np.array(images['Marker'].convert('L').convert('RGB'))
-    marker_pix[:, :, 2] = 0
+    if color_marker:
+      marker_pix[:, :, 2] = 0
     images['Marker'] = Image.fromarray(marker_pix)
 
     # images['Marker'] = stitch(
@@ -317,7 +325,8 @@ def postprocess(img, seg_img, thresh=80, noise_objects_size=20, small_object_siz
     return images, scoring
 
 
-def infer_modalities(img, tile_size, model_dir, eager_mode=False):
+def infer_modalities(img, tile_size, model_dir, eager_mode=False,
+                     color_dapi=False, color_marker=False):
     """
     This function is used to infer modalities for the given image using a trained model.
     :param img: The input image.
@@ -335,7 +344,9 @@ def infer_modalities(img, tile_size, model_dir, eager_mode=False):
         tile_size=tile_size,
         overlap_size=compute_overlap(img.size, tile_size),
         model_path=model_dir,
-        eager_mode=eager_mode
+        eager_mode=eager_mode,
+        color_dapi=color_dapi,
+        color_marker=color_marker
     )
 
     post_images, scoring = postprocess(img, images['Seg'], small_object_size=20)

--- a/deepliif/models/base_model.py
+++ b/deepliif/models/base_model.py
@@ -3,6 +3,7 @@ import torch
 from collections import OrderedDict
 from abc import ABC, abstractmethod
 from . import networks
+from ..util import disable_batchnorm_tracking_stats
 
 
 class BaseModel(ABC):
@@ -90,6 +91,7 @@ class BaseModel(ABC):
             if isinstance(name, str):
                 net = getattr(self, 'net' + name)
                 net.eval()
+                net = disable_batchnorm_tracking_stats(net)
 
     def test(self):
         """Forward function used in test time.

--- a/test.py
+++ b/test.py
@@ -40,7 +40,9 @@ if __name__ == '__main__':
     
     # retrieve options used in training setting, similar to 
     # https://github.com/nadeemlab/DeepLIIF/blob/cc4deffca64b8865415ba665290d7971b821b1bd/deepliif/models/__init__.py#L115
-    model_dir = opt.checkpoints_dir
+    # model_dir in init_nets() is equivalent to save_dir in basemodel init
+    # https://github.com/nadeemlab/DeepLIIF/blob/cc4deffca64b8865415ba665290d7971b821b1bd/deepliif/models/base_model.py#L36
+    model_dir = os.path.join(opt.checkpoints_dir, opt.name)
     files = os.listdir(model_dir)
     for f in files:
         if 'train_opt.txt' in f:

--- a/test.py
+++ b/test.py
@@ -71,8 +71,9 @@ if __name__ == '__main__':
     # test with eval mode. This only affects layers like batchnorm and dropout.
     # For [pix2pix]: we use batchnorm and dropout in the original pix2pix. You can experiment it with and without eval() mode.
     # For [CycleGAN]: It should not affect CycleGAN as CycleGAN uses instancenorm without dropout.
-    if opt.eval:
-        model.eval()
+    model.eval()
+    # if opt.eval:
+    #     model.eval()
 
     _start_time = time.time()
 

--- a/test.py
+++ b/test.py
@@ -30,13 +30,29 @@ import os
 import time
 from deepliif.options.test_options import TestOptions
 from deepliif.data import create_dataset
-from deepliif.models import create_model
+from deepliif.models import create_model, read_model_params
 from deepliif.util.visualizer import save_images
 from deepliif.util import html
 
 
 if __name__ == '__main__':
     opt = TestOptions().parse()  # get test options
+    
+    # retrieve options used in training setting, similar to 
+    # https://github.com/nadeemlab/DeepLIIF/blob/cc4deffca64b8865415ba665290d7971b821b1bd/deepliif/models/__init__.py#L115
+    model_dir = opt.checkpoints_dir
+    files = os.listdir(model_dir)
+    for f in files:
+        if 'train_opt.txt' in f:
+            param_dict = read_model_params(os.path.join(model_dir, f))
+            opt.input_nc = int(param_dict['input_nc'])
+            opt.output_nc = int(param_dict['output_nc'])
+            opt.ngf = int(param_dict['ngf'])
+            opt.norm = param_dict['norm']
+            # opt.use_dropout = False if param_dict['no_dropout'] == 'True' else True # in DeepLIIFModel(), the option used is opt.no_dropout not opt.use_dropout
+            # opt.padding_type = param_dict['padding'] # in DeepLIIFModel(), the option used is opt.padding not opt.padding_type
+            opt.padding = param_dict['padding'] 
+    
     # hard-code some parameters for test
     opt.num_threads = 0   # test code only supports num_threads = 1
     opt.batch_size = 1    # test code only supports batch_size = 1


### PR DESCRIPTION
This PR for the main branch is intended to allow reproducible predictions, mainly to match to #24 extension branch fix, with additional main-branch-specific improvements for this purpose.

In summary, it contains basically 3 parts:
1. Fixed an issue that made `test.py` not runnable on the published models
2. Stabilized predictions as in #24
3. Added flag `--color-dapi` and `--color-marker` for `cli.py test` that allows to selectively reproduce the same coloring as in the paper

----
#### Issue 1: Cannot run execute `test.py` on the published models
Error message complains about missing & unexpected layers. This is essentially caused by a relatively recent addition of argument `padding_type` in the code. Prior to that commit, padding type likely was hard-coded and `zero` was used, as recorded in the training opts text file. After that commit, the padding type used when rebuilding the model was defaulted to `reflect`.

Although this padding type is a configurable option and is properly picked up by the downstream code, instead of loading some essential model-related information from the training opts text file (this is what `cli.py test`), `test.py` hard-coded the needed options. This leads to a conflict - the model we want to rebuild is trained with `padding_type="zero"` but the re-created model object has `padding_type="reflect"`, which impacts the constructed layers. It's not a surprise that loading weights ends up with error messages.

The fix implemented allows `test.py` to load essential model-related information from the training opts text file, just like what `cli.py test` does.

#### Issue 2: Unstable predictions
It's pretty much the same as in #24 . The only little differences are that 1) when reconstructing nets from serialized files, I moved the application of disable norm layers to function `load_torchscript_model()`, and 2) at the same place I now have to explicitly set the net to `eval()` mode, which I didn't have to for the extension branch - not setting this in the main branch would cause variations :( not quite sure why since I thought the torchscript models by default are loaded in eval mode, but it doesn't harm to explicitly set it anyway.

||model files|command|
|-|-|-|
|1|original files|python test.py|
|2|original files|python cli.py test --eager-mode|
|3|serialized files|python cli.py test|

Using image `Lung_24000_28000_1_1_1.20_0.70`:
|method|method|avg diff in predicted values per pixel - before this PR|avg diff in predicted values per pixel - after this PR|note|
|-|-|-|-|-|
|2|1|-0.01780|-0.0067|the before result is not a fair comparison because of the color difference; the after result is better than in #24 because the extension branch as of that time suffered from the mismatch of the tile size 1024 that the model was trained on vs. the hard-coded size of 512 to resize images to|
|3|2|-8.9369e-06|-8.786e-07|~~the before result is not a fair comparison because of the color difference~~ (they have the same color!); the difference in the after result is neglectable|

For any two runs using the same command, the produced images should be identical regardless of the command:
||model files|command|reproducible predictions - before this PR|reproducible predictions - after this PR|
|-|-|-|-|-|
|1|original files|python test.py|**N**|Y*|
|2|original files|python cli.py test --eager-mode|**N**|Y|
|3|serialized files|python cli.py test|**N**|Y|

\*: There is a slight difference (-1.9946e-08 per pixel) in `SegRefined`. Other than that, the generated pixels are exactly the same. I didn't look into what caused it yet as it seems to be small enough.

[attachment.zip](https://github.com/nadeemlab/DeepLIIF/files/10893563/attachment.zip)

#### Issue 3: Color difference
Before this PR, `DAPI` and `Marker` predictions generated from `test.py` were greyscale (same as the training data), while those generated from `cli.py test` were in light blue/yellow color to match the images in the paper. This made similarity comparison a headache.

To counter that, two flags `--color-dapi` and `--color-marker` were added to `cli.py test` so that it's optional to either keep the color, or to use greyscale to match those produced by `test.py`.
