### PR TITLE
Unpaired Image Generation

### DIFF
--- a/PostProcessSegmentationMask.py
+++ b/PostProcessSegmentationMask.py
@@ -6,10 +6,10 @@ import cv2
 import numpy as np
 import scipy.ndimage as ndi
 
-from deepliif.postprocessing import compute_results
+from deepliif.postprocessing import compute_final_results
 
 
-def post_process_segmentation_mask(input_dir, seg_thresh=150, size_thresh='auto'):
+def post_process_segmentation_mask(input_dir, seg_thresh=150, size_thresh='default'):
     images = os.listdir(input_dir)
     image_extensions = ['.png', '.jpg', '.tif', '.tiff']
 
@@ -40,7 +40,7 @@ def post_process_segmentation_mask(input_dir, seg_thresh=150, size_thresh='auto'
             else:
                 orig_image = cv2.cvtColor(cv2.imread(seg_file), cv2.COLOR_BGR2RGB)
             seg_image = cv2.cvtColor(cv2.imread(seg_file), cv2.COLOR_BGR2RGB)
-            overlaid, refined, scoring = compute_results(orig_image, seg_image, None, '40x', seg_thresh, size_thresh)
+            overlaid, refined, scoring = compute_final_results(orig_image, seg_image, None, '40x', size_thresh, seg_thresh=seg_thresh)
             if orig_file is not None:
                 cv2.imwrite(overlaid_file, cv2.cvtColor(overlaid, cv2.COLOR_RGB2BGR))
             cv2.imwrite(refined_file, cv2.cvtColor(refined, cv2.COLOR_RGB2BGR))
@@ -52,7 +52,7 @@ def post_process_segmentation_mask(input_dir, seg_thresh=150, size_thresh='auto'
 if __name__ == '__main__':
     base_dir = sys.argv[1]
     segmentation_thresh = 150
-    size_thresh = 'auto'
+    size_thresh = 'default'
     if len(sys.argv) > 2:
         segmentation_thresh = int(sys.argv[2])
     if len(sys.argv) > 3:

--- a/cli.py
+++ b/cli.py
@@ -97,6 +97,8 @@ def cli():
               help='network initialization [normal | xavier | kaiming | orthogonal]')
 @click.option('--init-gain', default=0.02, help='scaling factor for normal, xavier and orthogonal.')
 @click.option('--no-dropout', is_flag=True, help='no dropout for the generator')
+@click.option('--upsample', default='convtranspose', help='use upsampling instead of convtranspose [convtranspose | resize_conv | pixel_shuffle]')
+@click.option('--label-smoothing', type=float,default=0.0, help='label smoothing factor to prevent the discriminator from being too confident')
 # dataset parameters
 @click.option('--direction', default='AtoB', help='AtoB or BtoA')
 @click.option('--serial-batches', is_flag=True,
@@ -135,7 +137,9 @@ def cli():
 @click.option('--optimizer', type=str, default='adam',
               help='optimizer from torch.optim to use, applied to both generators and discriminators [adam | sgd | adamw | ...]; the current parameters however are set up for adam, so other optimziers may encounter issue')
 @click.option('--beta1', default=0.5, help='momentum term of adam')
-@click.option('--lr', default=0.0002, help='initial learning rate for adam')
+#@click.option('--lr', default=0.0002, help='initial learning rate for adam')
+@click.option('--lr-g', default=0.0002, help='initial learning rate for generator adam optimizer')
+@click.option('--lr-d', default=0.0002, help='initial learning rate for discriminator adam optimizer')
 @click.option('--lr-policy', default='linear',
               help='learning rate policy. [linear | step | plateau | cosine]')
 @click.option('--lr-decay-iters', type=int, default=50,
@@ -184,11 +188,11 @@ def cli():
               help='debug mode, limits the number of data points per epoch to a small value')
 @click.option('--debug-data-size', default=10, type=int, help='data size per epoch used in debug mode; due to batch size, the epoch will be passed once the completed no. data points is greater than this value (e.g., for batch size 3, debug data size 10, the effective size used in training will be 12)')
 def train(dataroot, name, gpu_ids, checkpoints_dir, input_nc, output_nc, ngf, ndf, net_d, net_g,
-          n_layers_d, norm, init_type, init_gain, no_dropout, direction, serial_batches, num_threads,
+          n_layers_d, norm, init_type, init_gain, no_dropout, upsample, label_smoothing, direction, serial_batches, num_threads,
           batch_size, load_size, crop_size, max_dataset_size, preprocess, no_flip, display_winsize, epoch, load_iter,
           verbose, lambda_l1, is_train, display_freq, display_ncols, display_id, display_server, display_env,
           display_port, update_html_freq, print_freq, no_html, save_latest_freq, save_epoch_freq, save_by_iter,
-          continue_train, epoch_count, phase, lr_policy, n_epochs, n_epochs_decay, optimizer, beta1, lr, lr_decay_iters,
+          continue_train, epoch_count, phase, lr_policy, n_epochs, n_epochs_decay, optimizer, beta1, lr_g, lr_d, lr_decay_iters,
           remote, remote_transfer_cmd, seed, dataset_mode, padding, model, seg_weights, loss_weights_g, loss_weights_d,
           modalities_no, seg_gen, net_ds, net_gs, gan_mode, gan_mode_s, local_rank, with_val, debug, debug_data_size):
     """General-purpose training script for multi-task image-to-image translation.
@@ -202,7 +206,7 @@ def train(dataroot, name, gpu_ids, checkpoints_dir, input_nc, output_nc, ngf, nd
     plot, and save models.The script supports continue/resume training.
     Use '--continue_train' to resume your previous training.
     """
-    assert model in ['DeepLIIF','DeepLIIFExt','SDG'], f'model class {model} is not implemented'
+    assert model in ['DeepLIIF','DeepLIIFExt','SDG','CycleGAN'], f'model class {model} is not implemented'
     if model == 'DeepLIIF':
         seg_no = 1
     elif model == 'DeepLIIFExt':
@@ -210,9 +214,12 @@ def train(dataroot, name, gpu_ids, checkpoints_dir, input_nc, output_nc, ngf, nd
             seg_no = modalities_no
         else:
             seg_no = 0
-    else: # SDG
+    else: # SDG, CycleGAN
         seg_no = 0
         seg_gen = False
+    
+    if model == 'CycleGAN':
+        dataset_mode = "unaligned"
     
     if optimizer != 'adam':
         print(f'Optimizer torch.optim.{optimizer} is not tested. Be careful about the parameters of the optimizer.')
@@ -247,22 +254,53 @@ def train(dataroot, name, gpu_ids, checkpoints_dir, input_nc, output_nc, ngf, nd
         print('padding type is forced to zero padding, because neither refection pad2d or replication pad2d has a deterministic implementation')
 
     # infer number of input images
-    dir_data_train = dataroot + '/train'
-    fns = os.listdir(dir_data_train)
-    fns = [x for x in fns if x.endswith('.png')]
-    print(f'{len(fns)} images found')
-    img = Image.open(f"{dir_data_train}/{fns[0]}")
-    print(f'image shape:',img.size)
     
-    num_img = img.size[0] / img.size[1]
-    assert int(num_img) == num_img, f'img size {img.size[0]} / {img.size[1]} = {num_img} is not an integer'
-    num_img = int(num_img)
     
-    input_no = num_img - modalities_no - seg_no
-    assert input_no > 0, f'inferred number of input images is {input_no} (modalities_no {modalities_no}, seg_no {seg_no}); should be greater than 0'
+    if dataset_mode == 'unaligned':
+        dir_data_train = dataroot + '/trainA'
+        fns = os.listdir(dir_data_train)
+        fns = [x for x in fns if x.endswith('.png')]
+        print(f'{len(fns)} images found in trainA')
+        img = Image.open(f"{dir_data_train}/{fns[0]}")
+        print(f'image shape:',img.size)
+
+        for i in range(1, modalities_no + 1):
+            dir_data_train = dataroot + f'/trainB{i}'
+            fns = os.listdir(dir_data_train)
+            fns = [x for x in fns if x.endswith('.png')]
+            print(f'{len(fns)} images found in trainB{i}')
+            img = Image.open(f"{dir_data_train}/{fns[0]}")
+            print(f'image shape:',img.size)
+        
+        input_no = None
+        num_img = None
+        
+        lambda_identity = 0
+        pool_size = 50 # https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/blob/master/scripts/train_cyclegan.sh
+        
+    else:
+        dir_data_train = dataroot + '/train'
+        fns = os.listdir(dir_data_train)
+        fns = [x for x in fns if x.endswith('.png')]
+        print(f'{len(fns)} images found')
+        img = Image.open(f"{dir_data_train}/{fns[0]}")
+        print(f'image shape:',img.size)
+        
+        num_img = img.size[0] / img.size[1]
+        assert int(num_img) == num_img, f'img size {img.size[0]} / {img.size[1]} = {num_img} is not an integer'
+        num_img = int(num_img)
+        
+        input_no = num_img - modalities_no - seg_no
+        assert input_no > 0, f'inferred number of input images is {input_no} (modalities_no {modalities_no}, seg_no {seg_no}); should be greater than 0'
+        
+        pool_size = 0
+        
     d_params['input_no'] = input_no
     d_params['scale_size'] = img.size[1]
     d_params['gpu_ids'] = gpu_ids
+    d_params['lambda_identity'] = 0
+    d_params['pool_size'] = pool_size
+    
     
     # update generator arch
     net_g = net_g.split(',')
@@ -745,26 +783,40 @@ def serialize(model_dir, output_dir, device, epoch, verbose):
 @click.option('--output-dir', help='saves results here.')
 @click.option('--tile-size', type=click.IntRange(min=1, max=None), required=True, help='tile size')
 @click.option('--model-dir', default='./model-server/DeepLIIF_Latest_Model/', help='load models from here.')
+@click.option('--filename-pattern', default='*', help='run inference on files of which the name matches the pattern.')
 @click.option('--gpu-ids', type=int, multiple=True, help='gpu-ids 0 gpu-ids 1 or gpu-ids -1 for CPU')
 @click.option('--region-size', default=20000, help='Due to limits in the resources, the whole slide image cannot be processed in whole.'
                                                    'So the WSI image is read region by region. '
                                                    'This parameter specifies the size each region to be read into GPU for inferrence.')
 @click.option('--eager-mode', is_flag=True, help='use eager mode (loading original models, otherwise serialized ones)')
+@click.option('--epoch', default='latest',
+              help='for eager mode, which epoch to load? set to latest to use latest cached model')
 @click.option('--color-dapi', is_flag=True, help='color dapi image to produce the same coloring as in the paper')
 @click.option('--color-marker', is_flag=True, help='color marker image to produce the same coloring as in the paper')
-def test(input_dir, output_dir, tile_size, model_dir, gpu_ids, region_size, eager_mode,
-         color_dapi, color_marker):
+@click.option('--BtoA', is_flag=True, help='for models trained with unaligned dataset, this flag instructs to load generatorB instead of generatorA')
+def test(input_dir, output_dir, tile_size, model_dir, filename_pattern, gpu_ids, region_size, eager_mode, epoch,
+         color_dapi, color_marker, btoa):
     
     """Test trained models
     """
     output_dir = output_dir or input_dir
     ensure_exists(output_dir)
 
-    image_files = [fn for fn in os.listdir(input_dir) if allowed_file(fn)]
+    if filename_pattern == '*':
+        print('use all alowed files')
+        image_files = [fn for fn in os.listdir(input_dir) if allowed_file(fn)]
+    else:
+        import glob
+        print('match files using filename pattern',filename_pattern)
+        image_files = [os.path.basename(f) for f in glob.glob(os.path.join(input_dir, filename_pattern))]
+    print(len(image_files),'image files')
+    
     files = os.listdir(model_dir)
     assert 'train_opt.txt' in files, f'file train_opt.txt is missing from model directory {model_dir}'
     opt = Options(path_file=os.path.join(model_dir,'train_opt.txt'), mode='test')
     opt.use_dp = False
+    opt.BtoA = btoa
+    opt.epoch = epoch
     
     number_of_gpus_all = torch.cuda.device_count()
     if number_of_gpus_all < len(gpu_ids) and -1 not in gpu_ids:
@@ -930,4 +982,9 @@ def visualize(pickle_dir, display_env):
 
 
 if __name__ == '__main__':
+    # tensor float 32 is available on nvidia ampere cards (e.g, a100, a40) and provides better performance at the cost of a bit lower precision
+    # in 1.7-1.11, pytorch by default enables tf32 when possible 
+    # currently convolutions still uses tf32 by default while matmul does not and needs to be enabled manually
+    # see this issue for a discussion: https://github.com/pytorch/pytorch/issues/67384
+    torch.backends.cuda.matmul.allow_tf32 = True
     cli()

--- a/cli.py
+++ b/cli.py
@@ -272,7 +272,7 @@ def train(dataroot, name, gpu_ids, checkpoints_dir, input_nc, output_nc, ngf, nd
             img = Image.open(f"{dir_data_train}/{fns[0]}")
             print(f'image shape:',img.size)
         
-        input_no = None
+        input_no = 1
         num_img = None
         
         lambda_identity = 0
@@ -554,6 +554,8 @@ def train(dataroot, name, gpu_ids, checkpoints_dir, input_nc, output_nc, ngf, nd
               help='network initialization [normal | xavier | kaiming | orthogonal]')
 @click.option('--init-gain', default=0.02, help='scaling factor for normal, xavier and orthogonal.')
 @click.option('--no-dropout', is_flag=True, help='no dropout for the generator')
+@click.option('--upsample', default='convtranspose', help='use upsampling instead of convtranspose [convtranspose | resize_conv | pixel_shuffle]')
+@click.option('--label-smoothing', type=float,default=0.0, help='label smoothing factor to prevent the discriminator from being too confident')
 # dataset parameters
 @click.option('--direction', default='AtoB', help='AtoB or BtoA')
 @click.option('--serial-batches', is_flag=True,
@@ -592,7 +594,9 @@ def train(dataroot, name, gpu_ids, checkpoints_dir, input_nc, output_nc, ngf, nd
 @click.option('--optimizer', type=str, default='adam',
               help='optimizer from torch.optim to use, applied to both generators and discriminators [adam | sgd | adamw | ...]; the current parameters however are set up for adam, so other optimziers may encounter issue')
 @click.option('--beta1', default=0.5, help='momentum term of adam')
-@click.option('--lr', default=0.0002, help='initial learning rate for adam')
+#@click.option('--lr', default=0.0002, help='initial learning rate for adam')
+@click.option('--lr-g', default=0.0002, help='initial learning rate for generator adam optimizer')
+@click.option('--lr-d', default=0.0002, help='initial learning rate for discriminator adam optimizer')
 @click.option('--lr-policy', default='linear',
               help='learning rate policy. [linear | step | plateau | cosine]')
 @click.option('--lr-decay-iters', type=int, default=50,

--- a/conftest.py
+++ b/conftest.py
@@ -30,6 +30,14 @@ MODEL_INFO = {'latest':{'model':'DeepLIIF', # cli.py train looks for subfolder "
                      'dir_model':['../checkpoints/sdg_20240104'],
                      'modalities_no': [4],
                      'seg_gen':[False],
+                     'tile_size':512},
+              'cyclegan':{'model':'CycleGAN',
+                     'dir_input_train':['Datasets/Sample_Dataset_cyclegan'],
+                     'dir_input_testpy':['Datasets/Sample_Dataset_cyclegan'],
+                     'dir_input_inference':['Datasets/Sample_Dataset_cyclegan/test_cli'],
+                     'dir_model':['../checkpoints/pasto3mods_test'],
+                     'modalities_no': [1],
+                     'seg_gen':[False],
                      'tile_size':512}}
 
 def pytest_addoption(parser):

--- a/conftest.py
+++ b/conftest.py
@@ -26,7 +26,7 @@ MODEL_INFO = {'latest':{'model':'DeepLIIF', # cli.py train looks for subfolder "
               'sdg':{'model':'SDG',
                      'dir_input_train':['Datasets/Sample_Dataset_sdg'],
                      'dir_input_testpy':['Datasets/Sample_Dataset_sdg'],
-                     'dir_input_inference':['Datasets/Sample_Dataset/test_cli'],
+                     'dir_input_inference':['Datasets/Sample_Dataset_sdg/test_cli'],
                      'dir_model':['../checkpoints/sdg_20240104'],
                      'modalities_no': [4],
                      'seg_gen':[False],
@@ -56,3 +56,10 @@ def model_info(model_type):
 @pytest.fixture(scope="session")
 def model_dir(model_info):
     return model_info['dir_model']
+
+@pytest.fixture(scope="session")
+def foldername_suffix(model_info):
+    if model_info['model'] in ['CycleGAN']:
+        return 'A' # trainA, testA, ...
+    else:
+        return '' # train, test, ...

--- a/deepliif/data/unaligned_dataset.py
+++ b/deepliif/data/unaligned_dataset.py
@@ -1,5 +1,5 @@
 import os.path
-from deepliif.data.base_dataset import BaseDataset, get_transform
+from deepliif.data.base_dataset import BaseDataset, get_params, get_transform
 from deepliif.data.image_folder import make_dataset
 from PIL import Image
 import random
@@ -16,25 +16,39 @@ class UnalignedDataset(BaseDataset):
     '/path/to/data/testA' and '/path/to/data/testB' during test time.
     """
 
-    def __init__(self, opt):
+    def __init__(self, opt, phase='train'):
         """Initialize this dataset class.
 
         Parameters:
             opt (Option class) -- stores all the experiment flags; needs to be a subclass of BaseOptions
         """
         BaseDataset.__init__(self, opt)
-        self.dir_A = os.path.join(opt.dataroot, opt.phase + 'A')  # create a path '/path/to/data/trainA'
-        self.dir_B = os.path.join(opt.dataroot, opt.phase + 'B')  # create a path '/path/to/data/trainB'
+        self.opt = opt
+        self.input_nc = opt.output_nc if opt.direction == 'BtoA' else opt.input_nc
+        self.output_nc = opt.input_nc if opt.direction == 'BtoA' else opt.output_nc
+        self.preprocess = opt.preprocess
+        self.no_flip = opt.no_flip
+        self.modalities_no = opt.modalities_no
+        self.seg_no = opt.seg_no
+        self.input_no = opt.input_no
+        self.seg_gen = opt.seg_gen
+        self.load_size = opt.load_size
+        self.crop_size = opt.crop_size
+        self.model = opt.model
+        
+        self.dir_A = os.path.join(opt.dataroot, phase + 'A')  # create a path '/path/to/data/trainA'
+        # trainB1/trainB2/trainB3... are organized as elements of DATASET B which is a list 
+        self.dirs_B = [os.path.join(opt.dataroot, phase + f'B{i}') for i in range(1,self.modalities_no+1)]  # create a list of paths ['/path/to/data/trainB',...]
 
         self.A_paths = sorted(make_dataset(self.dir_A, opt.max_dataset_size))   # load images from '/path/to/data/trainA'
-        self.B_paths = sorted(make_dataset(self.dir_B, opt.max_dataset_size))    # load images from '/path/to/data/trainB'
+        self.B_paths = [sorted(make_dataset(dir_B, opt.max_dataset_size)) for dir_B in self.dirs_B]    # load images from '/path/to/data/trainB', '/path/to/data/trainC', ...
         self.A_size = len(self.A_paths)  # get the size of dataset A
-        self.B_size = len(self.B_paths)  # get the size of dataset B
+        self.B_sizes = [len(B_paths) for B_paths in self.B_paths]  # get the size of dataset B1, B2, B3, ...
         btoA = self.opt.direction == 'BtoA'
         input_nc = self.opt.output_nc if btoA else self.opt.input_nc       # get the number of channels of input image
         output_nc = self.opt.input_nc if btoA else self.opt.output_nc      # get the number of channels of output image
-        self.transform_A = get_transform(self.opt, grayscale=(input_nc == 1))
-        self.transform_B = get_transform(self.opt, grayscale=(output_nc == 1))
+        
+        
 
     def __getitem__(self, index):
         """Return a data point and its metadata information.
@@ -50,22 +64,27 @@ class UnalignedDataset(BaseDataset):
         """
         A_path = self.A_paths[index % self.A_size]  # make sure index is within then range
         if self.opt.serial_batches:   # make sure index is within then range
-            index_B = index % self.B_size
+            indice_B = [index % B_size for B_size in self.B_sizes]
         else:   # randomize the index for domain B to avoid fixed pairs.
-            index_B = random.randint(0, self.B_size - 1)
-        B_path = self.B_paths[index_B]
+            indice_B = [random.randint(0, B_size - 1) for B_size in self.B_sizes]
+        B_paths = [B_paths[index_B] for B_paths, index_B in zip(self.B_paths, indice_B)]
+        
         A_img = Image.open(A_path).convert('RGB')
-        B_img = Image.open(B_path).convert('RGB')
+        B_imgs = [Image.open(B_path).convert('RGB') for B_path in B_paths]
+        
         # apply image transformation
-        A = self.transform_A(A_img)
-        B = self.transform_B(B_img)
-
-        return {'A': A, 'B': B, 'A_paths': A_path, 'B_paths': B_path}
+        transform_params = get_params(self.preprocess, self.load_size, self.crop_size, A_img.size)
+        A_transform = get_transform(self.preprocess, self.load_size, self.crop_size, self.no_flip, transform_params, grayscale=(self.input_nc == 1))
+        B_transform = get_transform(self.preprocess, self.load_size, self.crop_size, self.no_flip, transform_params, grayscale=(self.output_nc == 1))
+        A = A_transform(A_img)
+        Bs = [B_transform(B_img) for B_img in B_imgs]
+        
+        return {'A': A, 'Bs': Bs, 'A_paths': A_path, 'B_paths': B_paths}
 
     def __len__(self):
         """Return the total number of images in the dataset.
 
-        As we have two datasets with potentially different number of images,
-        we take a maximum of
+        
+        The effective size of this dataset will be the size of datasetA through which we loop and grab a random/matching image B1/B2/B3... for
         """
-        return max(self.A_size, self.B_size)
+        return self.A_size #max(self.A_size, self.B_size)

--- a/deepliif/models/CycleGAN_model.py
+++ b/deepliif/models/CycleGAN_model.py
@@ -71,9 +71,14 @@ class CycleGANModel(BaseModel):
         # Code (vs. paper): G_A (G), G_B (F), D_A (D_Y), D_B (D_X)
         if isinstance(opt.net_g, str):
             self.opt.net_g = [self.opt.net_g] * self.mod_gen_no
-
-        self.netGA = nn.ModuleList()
-        self.netGB = nn.ModuleList()
+        
+        try:
+            self.netGA = nn.ModuleList()
+            self.netGB = nn.ModuleList()
+        except:
+            self.netGA = list()
+            self.netGB = list()
+        
         for i in range(self.mod_gen_no):
             if self.is_train or not self.opt.BtoA:
                 self.netGA.append(networks.define_G(self.opt.input_nc, self.opt.output_nc, self.opt.ngf, self.opt.net_g[i], self.opt.norm,

--- a/deepliif/models/CycleGAN_model.py
+++ b/deepliif/models/CycleGAN_model.py
@@ -1,0 +1,272 @@
+import torch
+from torch import nn
+import itertools
+from ..util.image_pool import ImagePool
+from .base_model import BaseModel
+from . import networks
+from .networks import get_optimizer
+
+# https://github.com/brownvc/R3GAN/blob/main/R3GAN/Trainer.py
+def ZeroCenteredGradientPenalty(Samples, Critics):
+    
+    # print(Samples.requires_grad, Critics.requires_grad)
+    Gradient, = torch.autograd.grad(outputs=Critics.sum(), inputs=Samples, create_graph=True)
+    return Gradient.square().sum([1, 2, 3])
+
+class CycleGANModel(BaseModel):
+    """
+    This class implements the CycleGAN model, for learning image-to-image translation without paired data.
+
+    The model training requires '--dataset_mode unaligned' dataset.
+    By default, it uses a '--netG resnet_9blocks' ResNet generator,
+    a '--netD basic' discriminator (PatchGAN introduced by pix2pix),
+    and a least-square GANs objective ('--gan_mode lsgan').
+
+    CycleGAN paper: https://arxiv.org/pdf/1703.10593.pdf
+    """
+
+    def __init__(self, opt):
+        """Initialize the CycleGAN class.
+
+        Parameters:
+            opt (Option class)-- stores all the experiment flags; needs to be a subclass of BaseOptions
+        """
+        BaseModel.__init__(self, opt)
+        self.mod_gen_no = self.opt.modalities_no
+        if not hasattr(self.opt,'upsample'):
+            self.opt.upsample = 'convtranspose'
+        if not hasattr(self.opt,'label_smoothing'):
+            self.opt.label_smoothing = 0
+        
+        use_spectral_norm = self.opt.norm == 'spectral'
+        
+        # self.seg_weights = opt.seg_weights
+        # assert len(self.seg_weights) == self.seg_gen_no, 'The number of the segmentation weights (seg_weights) is not equal to the number of target images (modalities_no)!'
+        # print(self.seg_weights)
+        # loss weights in calculating the final loss
+        self.loss_G_weights = [1 / self.mod_gen_no] * self.mod_gen_no
+        self.loss_D_weights = [1 / self.mod_gen_no] * self.mod_gen_no
+        self.loss_cyc_weights = [1 / self.mod_gen_no] * self.mod_gen_no
+        
+        self.opt.lambda_identity = 0 # do not use lambda identity for the first trial
+        # specify the training losses you want to print out. The training/test scripts will call <BaseModel.get_current_losses>
+        self.loss_names = ['D_A', 'G_A', 'cycle_A', 'idt_A', 'D_B', 'G_B', 'cycle_B', 'idt_B']
+        # specify the images you want to save/display. The training/test scripts will call <BaseModel.get_current_visuals>
+        l_suffix = range(1, self.opt.modalities_no + 1)
+        visual_names_A = [f'real_As_{i}' for i in l_suffix] + [f'fake_Bs_{i}' for i in l_suffix] + [f'rec_As_{i}' for i in l_suffix]
+        visual_names_B = [f'real_Bs_{i}' for i in l_suffix] + [f'fake_As_{i}' for i in l_suffix] + [f'rec_Bs_{i}' for i in l_suffix]
+
+        # if self.is_train and self.opt.lambda_identity > 0.0:  # if identity loss is used, we also visualize idt_B=G_A(B) ad idt_A=G_A(B)
+        #     visual_names_A.append('idt_B')
+        #     visual_names_B.append('idt_A')
+
+        self.visual_names = visual_names_A + visual_names_B  # combine visualizations for A and B
+        # specify the models you want to save to the disk. The training/test scripts will call <BaseModel.save_networks> and <BaseModel.load_networks>.
+        if self.is_train:
+            self.model_names = [f'GA_{i}' for i in l_suffix] + [f'GB_{i}' for i in l_suffix] + [f'DA_{i}' for i in l_suffix] + [f'DB_{i}' for i in l_suffix]
+        else:  # during test time, only load Gs
+            self.model_names = [f'GA_{i}' for i in l_suffix] + [f'GB_{i}' for i in l_suffix] 
+
+        # define networks (both Generators and discriminators)
+        # The naming is different from those used in the paper.
+        # Code (vs. paper): G_A (G), G_B (F), D_A (D_Y), D_B (D_X)
+        if isinstance(opt.net_g, str):
+            self.opt.net_g = [self.opt.net_g] * self.mod_gen_no
+
+        self.netGA = nn.ModuleList()#[None for _ in range(self.mod_gen_no)]
+        self.netGB = nn.ModuleList()#[None for _ in range(self.mod_gen_no)]
+        for i in range(self.mod_gen_no):
+            self.netGA.append(networks.define_G(self.opt.input_nc, self.opt.output_nc, self.opt.ngf, self.opt.net_g[i], self.opt.norm,
+                                             not self.opt.no_dropout, self.opt.init_type, self.opt.init_gain, self.gpu_ids, self.opt.padding, 
+                                            upsample=self.opt.upsample))
+            self.netGB.append(networks.define_G(self.opt.output_nc, self.opt.input_nc, self.opt.ngf, self.opt.net_g[i], self.opt.norm,
+                                             not self.opt.no_dropout, self.opt.init_type, self.opt.init_gain, self.gpu_ids, self.opt.padding, 
+                                             upsample=self.opt.upsample))
+        
+        if self.is_train:  # define a discriminator; conditional GANs need to take both input and output images; Therefore, #channels for D is input_nc + output_nc
+            self.netDA = nn.ModuleList()#[None for _ in range(self.mod_gen_no)]
+            self.netDB = nn.ModuleList()#[None for _ in range(self.mod_gen_no)]
+            for i in range(self.mod_gen_no):
+                self.netDA.append(networks.define_D(self.opt.output_nc, self.opt.ndf, self.opt.net_d,
+                                                 self.opt.n_layers_D, self.opt.norm, self.opt.init_type, self.opt.init_gain,
+                                                 self.gpu_ids))
+                self.netDB.append(networks.define_D(self.opt.input_nc, self.opt.ndf, self.opt.net_d,
+                                                 self.opt.n_layers_D, self.opt.norm, self.opt.init_type, self.opt.init_gain,
+                                                 self.gpu_ids))
+
+
+
+        if self.is_train:
+            if opt.lambda_identity > 0.0:  # only works when input and output images have the same number of channels
+                assert(opt.input_nc == opt.output_nc)
+            self.fake_A_pools = [ImagePool(opt.pool_size) for _ in range(self.opt.modalities_no)]  # create image buffer to store previously generated images
+            self.fake_B_pools = [ImagePool(opt.pool_size) for _ in range(self.opt.modalities_no)]  # create image buffer to store previously generated images
+            
+            # define loss functions
+            # label smoothing currently only applies to discriminator losses & generatoe of lsgan/vanilla
+            self.criterionGAN = networks.GANLoss(opt.gan_mode, label_smoothing=self.opt.label_smoothing).to(self.device)  # define GAN loss.
+            self.criterionCycle = torch.nn.L1Loss()
+            self.criterionIdt = torch.nn.L1Loss()
+            
+            self.criterionSmoothL1 = torch.nn.SmoothL1Loss()
+            self.criterionVGG = networks.VGGLoss().to(self.device)
+            
+            
+            # initialize optimizers
+            params = []
+            for i in range(len(self.netGA)):
+                params += list(self.netGA[i].parameters())
+            for i in range(len(self.netGB)):
+                params += list(self.netGB[i].parameters())
+            try:
+                self.optimizer_G = get_optimizer(opt.optimizer)(params, lr=opt.lr_g, betas=(opt.beta1, 0.999))
+            except:
+                print(f'betas are not used for optimizer torch.optim.{opt.optimizer} in generators')
+                self.optimizer_G = get_optimizer(opt.optimizer)(params, lr=opt.lr_g)
+            
+            params = []        
+            for i in range(len(self.netDA)):
+                params += list(self.netDA[i].parameters())
+            for i in range(len(self.netDB)):
+                params += list(self.netDB[i].parameters())
+            
+            # a smaller learning rate for discriminators to postpone training failure due to discriminators quickly become too strong
+            try:
+                self.optimizer_D = get_optimizer(opt.optimizer)(params, lr=opt.lr_d, betas=(opt.beta1, 0.999))
+            except:
+                print(f'betas are not used for optimizer torch.optim.{opt.optimizer} in generators')
+                self.optimizer_D = get_optimizer(opt.optimizer)(params, lr=opt.lr_d)
+            
+            
+            self.optimizers.append(self.optimizer_G)
+            self.optimizers.append(self.optimizer_D)
+
+    def set_input(self, input):
+        """Unpack input data from the dataloader and perform necessary pre-processing steps.
+
+        Parameters:
+            input (dict): include the data itself and its metadata information.
+
+        The option 'direction' can be used to swap domain A and domain B.
+        """
+        self.real_As = [input['A'].to(self.device) for _ in range(self.opt.modalities_no)]
+        self.real_Bs = [x.to(self.device) for x in input['Bs']]
+        self.image_paths = input['A_paths']
+
+    def forward(self):
+        """Run forward pass; called by both functions <optimize_parameters> and <test>."""
+        self.fake_Bs = [netGA(real_A) for netGA, real_A in zip(self.netGA, self.real_As)]  # G_A(A)
+        self.rec_As = [netGB(fake_B) for netGB, fake_B in zip(self.netGB, self.fake_Bs)]   # G_B(G_A(A))
+        
+        self.fake_As = [netGB(real_B) for netGB, real_B in zip(self.netGB, self.real_Bs)]  # G_B(B)
+        self.rec_Bs = [netGA(fake_A) for netGA, fake_A in zip(self.netGA, self.fake_As)]   # G_A(G_B(B))
+    
+      
+    def backward_D_basic(self, netD, real, fake, scale_factor=1):
+        """Calculate GAN loss for the discriminator
+
+        Parameters:
+            netD (network)      -- the discriminator D
+            real (tensor array) -- real images
+            fake (tensor array) -- images generated by a generator
+
+        Return the discriminator loss.
+        We also call loss_D.backward() to calculate the gradients.
+        """
+        # Real
+        pred_real = netD(real)
+        loss_D_real = self.criterionGAN(pred_real, True)
+        # Fake
+        pred_fake = netD(fake.detach())
+        loss_D_fake = self.criterionGAN(pred_fake, False)
+        # Combined loss and calculate gradients
+        loss_D = (loss_D_real + loss_D_fake) * 0.5 * scale_factor
+        loss_D.backward()
+        return loss_D
+
+    def backward_D_A(self):
+        """Calculate GAN loss for discriminator D_A"""
+        fake_Bs = [fake_B_pool.query(fake_B) for fake_B_pool, fake_B in zip(self.fake_B_pools, self.fake_Bs)]
+        real_Bs = self.real_Bs
+        
+        self.loss_D_A = 0
+        for i, (netDA, real_B, fake_B) in enumerate(zip(self.netDA, real_Bs, fake_Bs)):
+            self.loss_D_A += self.backward_D_basic(netDA, real_B, fake_B, scale_factor=self.loss_D_weights[i])
+        #self.loss_D_A.backward()
+
+    def backward_D_B(self):
+        """Calculate GAN loss for discriminator D_B"""
+        fake_As = [fake_A_pool.query(fake_A) for fake_A_pool, fake_A in zip(self.fake_A_pools, self.fake_As)]
+        real_As = self.real_As
+            
+        self.loss_D_B = 0
+        for i, (netDB, real_A, fake_A) in enumerate(zip(self.netDB, real_As, fake_As)):
+            self.loss_D_B += self.backward_D_basic(netDB, real_A, fake_A, scale_factor=self.loss_D_weights[i]) 
+        #self.loss_D_B.backward()
+
+    def backward_G(self):
+        """Calculate the loss for generators G_A and G_B"""
+        # default lambda values from cyclegan implementation:
+        # https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/blob/c3268edd50ec37a81600c9b981841f48929671b8/models/cycle_gan_model.py#L41
+        lambda_idt = 0#self.opt.lambda_identity # identity loss is used to preserve color consistency between input and output images, which we do not want to encourage
+        lambda_A = 10#self.opt.lambda_A 
+        lambda_B = 10#self.opt.lambda_B
+        # Identity loss
+        if lambda_idt > 0:
+            # G_A should be identity if real_B is fed: ||G_A(B) - B||
+            self.idt_A = self.netG_A(self.real_B)
+            self.loss_idt_A = self.criterionIdt(self.idt_A, self.real_B) * lambda_B * lambda_idt
+            # G_B should be identity if real_A is fed: ||G_B(A) - A||
+            self.idt_B = self.netG_B(self.real_A)
+            self.loss_idt_B = self.criterionIdt(self.idt_B, self.real_A) * lambda_A * lambda_idt
+        else:
+            self.loss_idt_A = 0
+            self.loss_idt_B = 0
+            
+        # GAN loss D_A(G_A(A))
+        self.loss_G_A = 0
+        for i, (netDA, fake_B, real_B) in enumerate(zip(self.netDA, self.fake_Bs, self.real_Bs)):
+            self.loss_G_A += self.criterionGAN(netDA(fake_B), True) * self.loss_G_weights[i]
+            self.loss_G_A += self.criterionVGG(fake_B, real_B) * self.loss_G_weights[i]
+        
+        # GAN loss D_B(G_B(B))
+        self.loss_G_B = 0
+        for i, (netDB, fake_A, real_A) in enumerate(zip(self.netDB, self.fake_As, self.real_As)):
+            self.loss_G_B += self.criterionGAN(netDB(fake_A), True) * self.loss_G_weights[i]
+            self.loss_G_B += self.criterionVGG(fake_A, real_A) * self.loss_G_weights[i]
+            
+        # Forward cycle loss || G_B(G_A(A)) - A||
+        self.loss_cycle_A = 0
+        for i, (rec_A, real_A) in enumerate(zip(self.rec_As, self.real_As)):
+            self.loss_cycle_A += self.criterionCycle(rec_A, real_A) * lambda_A * self.loss_cyc_weights[i]
+        # Backward cycle loss || G_A(G_B(B)) - B||
+        self.loss_cycle_B = 0
+        for i, (rec_B, real_B) in enumerate(zip(self.rec_Bs, self.real_Bs)):
+            self.loss_cycle_B += self.criterionCycle(rec_B, real_B) * lambda_B * self.loss_cyc_weights[i]
+        
+        # VGG loss
+        # self.loss_G_VGG = self.criterionVGG(self.fake_B_1, self.real_B_1) * self.opt.lambda_feat
+        
+        # smooth L1
+        # self.loss_G_A_L1 = self.criterionSmoothL1(self.fake_B_1, self.real_B_1) * self.opt.lambda_L1
+        
+        # combined loss and calculate gradients
+        self.loss_G = self.loss_G_A + self.loss_G_B + self.loss_cycle_A + self.loss_cycle_B + self.loss_idt_A + self.loss_idt_B
+        self.loss_G.backward()
+
+    def optimize_parameters(self):
+        """Calculate losses, gradients, and update network weights; called in every training iteration"""
+        # forward
+        self.forward()      # compute fake images and reconstruction images.
+        # G_A and G_B
+        self.set_requires_grad(self.netDA + self.netDB, False)  # Ds require no gradients when optimizing Gs
+        self.optimizer_G.zero_grad()  # set G_A and G_B's gradients to zero
+        self.backward_G()             # calculate gradients for G_A and G_B
+        self.optimizer_G.step()       # update G_A and G_B's weights
+        
+        # D_A and D_B
+        self.set_requires_grad(self.netDA + self.netDB, True)
+        self.optimizer_D.zero_grad()   # set D_A and D_B's gradients to zero
+        self.backward_D_A()      # calculate gradients for D_A
+        self.backward_D_B()      # calculate graidents for D_B
+        self.optimizer_D.step()  # update D_A and D_B's weights

--- a/deepliif/models/DeepLIIFExt_model.py
+++ b/deepliif/models/DeepLIIFExt_model.py
@@ -25,10 +25,10 @@ class DeepLIIFExtModel(BaseModel):
         # assert len(self.seg_weights) == self.seg_gen_no, 'The number of the segmentation weights (seg_weights) is not equal to the number of target images (modalities_no)!'
         # print(self.seg_weights)
         # loss weights in calculating the final loss
-        self.loss_G_weights = [1 / self.mod_gen_no] * self.mod_gen_no
+        self.loss_G_weights = opt.loss_G_weights
         self.loss_GS_weights = [1 / self.mod_gen_no] * self.mod_gen_no
 
-        self.loss_D_weights = [1 / self.mod_gen_no] * self.mod_gen_no
+        self.loss_D_weights = opt.loss_D_weights
         self.loss_DS_weights = [1 / self.mod_gen_no] * self.mod_gen_no
         
         # self.gpu_ids is a possibly modifed one for model initialization
@@ -114,10 +114,10 @@ class DeepLIIFExtModel(BaseModel):
                 if self.netGS[i]:
                     params += list(self.netGS[i].parameters())
             try:
-                self.optimizer_G = get_optimizer(opt.optimizer)(params, lr=opt.lr, betas=(opt.beta1, 0.999))
+                self.optimizer_G = get_optimizer(opt.optimizer)(params, lr=opt.lr_g, betas=(opt.beta1, 0.999))
             except:
                 print(f'betas are not used for optimizer torch.optim.{opt.optimizer} in generators')
-                self.optimizer_G = get_optimizer(opt.optimizer)(params, lr=opt.lr)
+                self.optimizer_G = get_optimizer(opt.optimizer)(params, lr=opt.lr_g)
 
             params = []
             for i in range(len(self.netD)):
@@ -126,10 +126,10 @@ class DeepLIIFExtModel(BaseModel):
                 if self.netDS[i]:
                     params += list(self.netDS[i].parameters())
             try:
-                self.optimizer_D = get_optimizer(opt.optimizer)(params, lr=opt.lr, betas=(opt.beta1, 0.999))
+                self.optimizer_D = get_optimizer(opt.optimizer)(params, lr=opt.lr_d, betas=(opt.beta1, 0.999))
             except:
                 print(f'betas are not used for optimizer torch.optim.{opt.optimizer} in discriminators')
-                self.optimizer_D = get_optimizer(opt.optimizer)(params, lr=opt.lr)
+                self.optimizer_D = get_optimizer(opt.optimizer)(params, lr=opt.lr_d)
 
             self.optimizers.append(self.optimizer_G)
             self.optimizers.append(self.optimizer_D)

--- a/deepliif/models/DeepLIIF_model.py
+++ b/deepliif/models/DeepLIIF_model.py
@@ -109,17 +109,17 @@ class DeepLIIFModel(BaseModel):
             # initialize optimizers; schedulers will be automatically created by function <BaseModel.setup>.
             params = list(self.netG1.parameters()) + list(self.netG2.parameters()) + list(self.netG3.parameters()) + list(self.netG4.parameters()) + list(self.netG51.parameters()) + list(self.netG52.parameters()) + list(self.netG53.parameters()) + list(self.netG54.parameters()) + list(self.netG55.parameters())
             try:
-                self.optimizer_G = get_optimizer(opt.optimizer)(params, lr=opt.lr, betas=(opt.beta1, 0.999))
+                self.optimizer_G = get_optimizer(opt.optimizer)(params, lr=opt.lr_g, betas=(opt.beta1, 0.999))
             except:
                 print(f'betas are not used for optimizer torch.optim.{opt.optimizer} in generators')
-                self.optimizer_G = get_optimizer(opt.optimizer)(params, lr=opt.lr)
+                self.optimizer_G = get_optimizer(opt.optimizer)(params, lr=opt.lr_g)
 
             params = list(self.netD1.parameters()) + list(self.netD2.parameters()) + list(self.netD3.parameters()) + list(self.netD4.parameters()) + list(self.netD51.parameters()) + list(self.netD52.parameters()) + list(self.netD53.parameters()) + list(self.netD54.parameters()) + list(self.netD55.parameters())
             try:
-                self.optimizer_D = get_optimizer(opt.optimizer)(params, lr=opt.lr, betas=(opt.beta1, 0.999))
+                self.optimizer_D = get_optimizer(opt.optimizer)(params, lr=opt.lr_d, betas=(opt.beta1, 0.999))
             except:
                 print(f'betas are not used for optimizer torch.optim.{opt.optimizer} in discriminators')
-                self.optimizer_D = get_optimizer(opt.optimizer)(params, lr=opt.lr)
+                self.optimizer_D = get_optimizer(opt.optimizer)(params, lr=opt.lr_d)
 
             self.optimizers.append(self.optimizer_G)
             self.optimizers.append(self.optimizer_D)

--- a/deepliif/models/SDG_model.py
+++ b/deepliif/models/SDG_model.py
@@ -25,10 +25,10 @@ class SDGModel(BaseModel):
         # assert len(self.seg_weights) == self.seg_gen_no, 'The number of the segmentation weights (seg_weights) is not equal to the number of target images (modalities_no)!'
 
         # loss weights in calculating the final loss
-        self.loss_G_weights = [1 / self.mod_gen_no] * self.mod_gen_no
+        self.loss_G_weights = opt.loss_G_weights
         self.loss_GS_weights = [1 / self.mod_gen_no] * self.mod_gen_no
 
-        self.loss_D_weights = [1 / self.mod_gen_no] * self.mod_gen_no
+        self.loss_D_weights = opt.loss_D_weights
         self.loss_DS_weights = [1 / self.mod_gen_no] * self.mod_gen_no
 
         # self.gpu_ids is a possibly modifed one for model initialization
@@ -88,19 +88,19 @@ class SDGModel(BaseModel):
             for i in range(len(self.netG)):
                 params += list(self.netG[i].parameters())
             try:
-                self.optimizer_G = get_optimizer(opt.optimizer)(params, lr=opt.lr, betas=(opt.beta1, 0.999))
+                self.optimizer_G = get_optimizer(opt.optimizer)(params, lr=opt.lr_g, betas=(opt.beta1, 0.999))
             except:
                 print(f'betas are not used for optimizer torch.optim.{opt.optimizer} in generators')
-                self.optimizer_G = get_optimizer(opt.optimizer)(params, lr=opt.lr)
+                self.optimizer_G = get_optimizer(opt.optimizer)(params, lr=opt.lr_g)
 
             params = []
             for i in range(len(self.netD)):
                 params += list(self.netD[i].parameters())
             try:
-                self.optimizer_D = get_optimizer(opt.optimizer)(params, lr=opt.lr, betas=(opt.beta1, 0.999))
+                self.optimizer_D = get_optimizer(opt.optimizer)(params, lr=opt.lr_d, betas=(opt.beta1, 0.999))
             except:
                 print(f'betas are not used for optimizer torch.optim.{opt.optimizer} in discriminators')
-                self.optimizer_D = get_optimizer(opt.optimizer)(params, lr=opt.lr)
+                self.optimizer_D = get_optimizer(opt.optimizer)(params, lr=opt.lr_d)
 
             self.optimizers.append(self.optimizer_G)
             self.optimizers.append(self.optimizer_D)

--- a/deepliif/models/__init__.py
+++ b/deepliif/models/__init__.py
@@ -12,7 +12,7 @@ In the function <__init__>, you need to define four lists:
     -- self.loss_names (str list):          specify the training losses that you want to plot and save.
     -- self.model_names (str list):         define networks used in our training.
     -- self.visual_names (str list):        specify the images that you want to display and save.
-    -- self.optimizers (optimizer list):    define and initialize optimizers. You can define one optimizer for each network. If two networks are updated at the same time, you can use itertools.chain to group them. See cycle_gan_model.py for an usage.
+    -- self.optimizers (optimizer list):    define and initialize optimizers. You can define one optimizer for each network. If two networks are updated at the same time, you can use itertools.chain to group them. See CycleGAN_model.py for an usage.
 
 Now you can use the model class by specifying flag '--model dummy'.
 See our template model class 'template_model.py' for more details.
@@ -27,6 +27,8 @@ from io import BytesIO
 import requests
 import torch
 from PIL import Image
+Image.MAX_IMAGE_PIXELS = 1000000000
+
 import numpy as np
 from dask import delayed, compute
 
@@ -122,7 +124,12 @@ def load_eager_models(opt, devices=None):
     model.setup(opt)
 
     nets = {}
-    for name in model.model_names:
+    if devices:
+        model_names = list(devices.keys())
+    else:
+        model_names = model.model_names
+    
+    for name in model_names:#model.model_names:
         if isinstance(name, str):
             if '_' in name:
                 net = getattr(model, 'net' + name.split('_')[0])[int(name.split('_')[-1]) - 1]
@@ -170,6 +177,11 @@ def init_nets(model_dir, eager_mode=False, opt=None, phase='test'):
             net_groups = [(f'G_{i+1}',f'GS_{i+1}') for i in range(opt.modalities_no)]
         else:
             net_groups = [(f'G_{i+1}',) for i in range(opt.modalities_no)]
+    elif opt.model == 'CycleGAN':
+        if opt.BtoA:
+            net_groups = [(f'GB_{i+1}',) for i in range(opt.modalities_no)]
+        else:
+            net_groups = [(f'GA_{i+1}',) for i in range(opt.modalities_no)]
     else:
         raise Exception(f'init_nets() not implemented for model {opt.model}')
 
@@ -229,6 +241,7 @@ def run_torchserve(img, model_path=None, eager_mode=False, opt=None):
 def run_dask(img, model_path, eager_mode=False, opt=None):
     model_dir = os.getenv('DEEPLIIF_MODEL_DIR', model_path)
     nets = init_nets(model_dir, eager_mode, opt)
+    use_dask = True if opt.norm != 'spectral' else False
     
     if opt.input_no > 1 or opt.model == 'SDG':
         l_ts = [transform(img_i.resize((opt.scale_size,opt.scale_size))) for img_i in img]
@@ -237,10 +250,15 @@ def run_dask(img, model_path, eager_mode=False, opt=None):
         ts = transform(img.resize((opt.scale_size, opt.scale_size)))
     
 
-    @delayed
-    def forward(input, model):
-        with torch.no_grad():
-            return model(input.to(next(model.parameters()).device))
+    if use_dask:
+        @delayed
+        def forward(input, model):
+            with torch.no_grad():
+                return model(input.to(next(model.parameters()).device))
+    else: # some train settings like spectral norm some how in inference mode is not compatible with dask
+        def forward(input, model):
+            with torch.no_grad():
+                return model(input.to(next(model.parameters()).device))
     
     if opt.model == 'DeepLIIF':
         seg_map = {'G1': 'G52', 'G2': 'G53', 'G3': 'G54', 'G4': 'G55'}
@@ -266,17 +284,26 @@ def run_dask(img, model_path, eager_mode=False, opt=None):
         res['G5'] = tensor_to_pil(seg)
     
         return res
-    elif opt.model in ['DeepLIIFExt','SDG']:
-        seg_map = {'G_' + str(i): 'GS_' + str(i) for i in range(1, opt.modalities_no + 1)}
+    elif opt.model in ['DeepLIIFExt','SDG','CycleGAN']:
+        if opt.model == 'CycleGAN':
+            seg_map = {f'GB_{i+1}':None for i in range(opt.modalities_no)} if opt.BtoA else {f'GA_{i+1}':None for i in range(opt.modalities_no)}
+        else:
+            seg_map = {'G_' + str(i): 'GS_' + str(i) for i in range(1, opt.modalities_no + 1)}
         
-        lazy_gens = {k: forward(ts, nets[k]) for k in seg_map}
-        gens = compute(lazy_gens)[0]
+        if use_dask:
+            lazy_gens = {k: forward(ts, nets[k]) for k in seg_map}
+            gens = compute(lazy_gens)[0]
+        else:
+            gens = {k: forward(ts, nets[k]) for k in seg_map}
         
         res = {k: tensor_to_pil(v) for k, v in gens.items()}
     
         if opt.seg_gen:
-            lazy_segs = {v: forward(torch.cat([ts.to(torch.device('cpu')), gens[next(iter(seg_map))].to(torch.device('cpu')), gens[k].to(torch.device('cpu'))], 1), nets[v]).to(torch.device('cpu')) for k, v in seg_map.items()}
-            segs = compute(lazy_segs)[0]
+            if use_dask:
+                lazy_segs = {v: forward(torch.cat([ts.to(torch.device('cpu')), gens[next(iter(seg_map))].to(torch.device('cpu')), gens[k].to(torch.device('cpu'))], 1), nets[v]).to(torch.device('cpu')) for k, v in seg_map.items()}
+                segs = compute(lazy_segs)[0]
+            else:
+                segs = {v: forward(torch.cat([ts.to(torch.device('cpu')), gens[next(iter(seg_map))].to(torch.device('cpu')), gens[k].to(torch.device('cpu'))], 1), nets[v]).to(torch.device('cpu')) for k, v in seg_map.items()}
             res.update({k: tensor_to_pil(v) for k, v in segs.items()})
     
         return res
@@ -324,6 +351,13 @@ def run_wrapper(tile, run_fn, model_path, eager_mode=False, opt=None):
             return res
         else:
             return run_fn(tile, model_path, eager_mode, opt)
+    elif opt.model in ['CycleGAN']:
+        if is_empty(tile):
+            net_names = ['GB_{i+1}' for i in range(opt.modalities_no)] if opt.BtoA else [f'GA_{i+1}' for i in range(opt.modalities_no)]
+            res = {net_name: Image.new(mode='RGB', size=(512, 512)) for net_name in net_names}
+            return res
+        else:
+            return run_fn(tile, model_path, eager_mode, opt)
     else:
         raise Exception(f'run_wrapper() not implemented for model {opt.model}')
 
@@ -335,7 +369,7 @@ def inference_old(img, tile_size, overlap_size, model_path, use_torchserve=False
 
     run_fn = run_torchserve if use_torchserve else run_dask
     # res = [Tile(t.i, t.j, run_fn(t.img, model_path)) for t in tiles]
-    res = [Tile(t.i, t.j, run_wrapper(t.img, run_fn, model_path, eager_mode)) for t in tiles]
+    res = [Tile(t.i, t.j, run_wrapper(t.img, run_fn, model_path, eager_modek)) for t in tiles]
 
     def get_net_tiles(n):
         return [Tile(t.i, t.j, t.img[n]) for t in res]

--- a/deepliif/models/__init__.py
+++ b/deepliif/models/__init__.py
@@ -28,7 +28,7 @@ import json
 import requests
 import torch
 from PIL import Image
-Image.MAX_IMAGE_PIXELS = 1000000000
+Image.MAX_IMAGE_PIXELS = None
 
 import numpy as np
 from dask import delayed, compute

--- a/deepliif/models/base_model.py
+++ b/deepliif/models/base_model.py
@@ -151,7 +151,14 @@ class BaseModel(ABC):
                             img_name = name[:-1] + '_' + name[-1]
                             visual_ret[name] = getattr(self, img_name)
                         else:
-                            visual_ret[name] = getattr(self, name.split('_')[0] + '_' + name.split('_')[1])[int(name.split('_')[-1]) - 1]
+                            if self.opt.model == 'CycleGAN':
+                                l_output = getattr(self, name.split('_')[0] + '_' + name.split('_')[1])
+                                if len(l_output) > 0:
+                                    visual_ret[name] = getattr(self, name.split('_')[0] + '_' + name.split('_')[1])[int(name.split('_')[-1]) - 1]
+                                else:
+                                    print('No output for',name)
+                            else:
+                                visual_ret[name] = getattr(self, name.split('_')[0] + '_' + name.split('_')[1])[int(name.split('_')[-1]) - 1]
                     else:
                         visual_ret[name] = getattr(self, name.split('_')[0])[int(name.split('_')[-1]) -1]
                 else:
@@ -261,13 +268,7 @@ class BaseModel(ABC):
                 load_filename = '%s_net_%s.pth' % (epoch, name)
                 load_path = os.path.join(self.save_dir, load_filename)
                 if '_' in name:
-                    if self.opt.model == 'CycleGAN':
-                        try:
-                            net = getattr(self, 'net'+name)
-                        except:
-                            net = getattr(self, 'net' + name.split('_')[0])[int(name.split('_')[-1]) - 1]
-                    else:
-                        net = getattr(self, 'net' + name.split('_')[0])[int(name.split('_')[-1]) - 1]
+                    net = getattr(self, 'net' + name.split('_')[0])[int(name.split('_')[-1]) - 1]
                 else:
                     net = getattr(self, 'net' + name)
                 if isinstance(net, torch.nn.DataParallel):

--- a/deepliif/options/__init__.py
+++ b/deepliif/options/__init__.py
@@ -72,7 +72,7 @@ class Options:
             self.input_nc = 3
             self.output_nc = 3
             self.ngf = 64
-            self.norm = 'batch'
+            self.norm = 'batch' if not hasattr(self,'norm') else self.norm
             self.use_dropout = True
             #self.padding_type = 'zero' # some models use reflect etc. which adds additional randomness 
             #self.padding = 'zero'

--- a/deepliif/options/__init__.py
+++ b/deepliif/options/__init__.py
@@ -78,6 +78,11 @@ class Options:
             #self.padding = 'zero'
             self.use_dropout = False #if self.no_dropout == 'True' else True
             
+            if self.model in ['CycleGAN']:
+                # this is only used for inference (whether to load generators Bs instead of As)
+                # and can be configured in the inference function
+                self.BtoA = False if not hasattr(self,'BtoA') else self.BtoA 
+            
             # reset checkpoints_dir and name based on the model directory
             # when base model is initialized: self.save_dir = os.path.join(opt.checkpoints_dir, opt.name) 
             model_dir = Path(path_file).parent

--- a/deepliif/postprocessing.py
+++ b/deepliif/postprocessing.py
@@ -1,73 +1,10 @@
 import math
-import cv2
-from PIL import Image
-import skimage.measure
-from skimage import feature
-from skimage.morphology import remove_small_objects
+import warnings
+
 import numpy as np
-import scipy.ndimage as ndi
-from numba import jit
-
-
-def remove_small_objects_from_image(img, min_size=100):
-    image_copy = img.copy()
-    image_copy[img > 0] = 1
-    image_copy = image_copy.astype(bool)
-    removed_red_channel = remove_small_objects(image_copy, min_size=min_size).astype(np.uint8)
-    img[removed_red_channel == 0] = 0
-
-    return img
-
-
-def remove_background_noise(mask, mask_boundary):
-    labeled = skimage.measure.label(mask, background=0)
-    padding = 5
-    for i in range(1, len(np.unique(labeled))):
-        component = np.zeros_like(mask)
-        component[labeled == i] = mask[labeled == i]
-        component_bound = np.zeros_like(mask_boundary)
-        component_bound[max(0, min(np.nonzero(component)[0]) - padding): min(mask_boundary.shape[1],
-                                                                             max(np.nonzero(component)[0]) + padding),
-        max(0, min(np.nonzero(component)[1]) - padding): min(mask_boundary.shape[1],
-                                                             max(np.nonzero(component)[1]) + padding)] \
-            = mask_boundary[max(0, min(np.nonzero(component)[0]) - padding): min(mask_boundary.shape[1], max(
-            np.nonzero(component)[0]) + padding),
-              max(0, min(np.nonzero(component)[1]) - padding): min(mask_boundary.shape[1],
-                                                                   max(np.nonzero(component)[1]) + padding)]
-        if len(np.nonzero(component_bound)[0]) < len(np.nonzero(component)[0]) / 3:
-            mask[labeled == i] = 0
-    return mask
-
-
-def remove_cell_noise(mask1, mask2):
-    labeled = skimage.measure.label(mask1, background=0)
-    padding = 2
-    for i in range(1, len(np.unique(labeled))):
-        component = np.zeros_like(mask1)
-        component[labeled == i] = mask1[labeled == i]
-        component_bound = np.zeros_like(mask2)
-        component_bound[
-        max(0, min(np.nonzero(component)[0]) - padding): min(mask2.shape[1], max(np.nonzero(component)[0]) + padding),
-        max(0, min(np.nonzero(component)[1]) - padding): min(mask2.shape[1], max(np.nonzero(component)[1]) + padding)] \
-            = mask2[max(0, min(np.nonzero(component)[0]) - padding): min(mask2.shape[1],
-                                                                         max(np.nonzero(component)[0]) + padding),
-              max(0, min(np.nonzero(component)[1]) - padding): min(mask2.shape[1],
-                                                                   max(np.nonzero(component)[1]) + padding)]
-        if len(np.nonzero(component_bound)[0]) > len(np.nonzero(component)[0]) / 3:
-            mask1[labeled == i] = 0
-            mask2[labeled == i] = 255
-    return mask1, mask2
-
-
-def create_basic_segmentation_mask(img, seg_img, thresh=80, noise_objects_size=20, small_object_size=50):
-    positive_mask, negative_mask = positive_negative_masks_basic(img, seg_img, thresh, noise_objects_size, small_object_size)
-
-    mask = np.zeros_like(img)
-
-    mask[positive_mask > 0] = (255, 0, 0)
-    mask[negative_mask > 0] = (0, 0, 255)
-
-    return mask
+from numba import jit, typed
+from PIL import Image
+Image.MAX_IMAGE_PIXELS = None
 
 
 def imadjust(x, gamma=0.7, c=0, d=1):
@@ -142,205 +79,267 @@ def adjust_marker(inferred_tile, orig_tile):
     return Image.fromarray(processed_tile)
 
 
-# Values for uint8 masks
-MASK_UNKNOWN = 50
-MASK_POSITIVE = 200
-MASK_NEGATIVE = 150
-MASK_BACKGROUND = 0
-MASK_CELL = 255
-MASK_CELL_POSITIVE = 201
-MASK_CELL_NEGATIVE = 151
-MASK_BOUNDARY_POSITIVE = 202
-MASK_BOUNDARY_NEGATIVE = 152
+# Default postprocessing values
+DEFAULT_SEG_THRESH = 150
+DEFAULT_NOISE_THRESH = 4
+
+# Values for uint8 label masks
+LABEL_UNKNOWN = 50
+LABEL_POSITIVE = 200
+LABEL_NEGATIVE = 150
+LABEL_BACKGROUND = 0
+LABEL_CELL = 100
+LABEL_BORDER_POS = 220
+LABEL_BORDER_NEG = 170
+LABEL_BORDER_POS2 = 221
+LABEL_BORDER_NEG2 = 171
+
+
+def to_array(img, grayscale=False):
+    """
+    Convert a color image to an array of pixels.
+
+    Parameters
+    ----------
+    img : Image | ndarray
+        Image to convert. If an array is provided instead, it is used directly.
+    grayscale : bool
+        Whether the input image should be converted to grayscale
+        by taking the maximum channel value for each pixel.
+
+    Returns
+    -------
+    ndarray
+        A 2D (grayscale) or 3D array with the pixels of the converted image.
+    """
+
+    if isinstance(img, Image.Image):
+        img = np.asarray(img) if img.mode == 'RGB' else np.asarray(img.convert('RGB'))
+    if grayscale and len(img.shape) == 3:
+        img = img.max(axis=-1)
+    return img
 
 
 @jit(nopython=True)
 def in_bounds(array, index):
+    """
+    Check if an index is valid for an array.
+
+    Parameters
+    ----------
+    array : ndarray
+        2D array.
+    index : tuple
+        2-element tuple with index values matching the array shape (e.g., for a pixel array where
+        array.shape[0] is height and array.shape[1] is width, then index will be in (y, x) order).
+
+    Returns
+    -------
+    bool
+        Whether or not the index is within the bounds of the array.
+    """
+
     return index[0] >= 0 and index[0] < array.shape[0] and index[1] >= 0 and index[1] < array.shape[1]
 
 
+@jit(nopython=True)
 def create_posneg_mask(seg, thresh):
-    """Create a mask of positive and negative pixels."""
+    """
+    Create a mask of positive and negative pixels from the segmentation image.
 
-    cell = np.logical_and(np.add(seg[:,:,0], seg[:,:,2], dtype=np.uint16) > thresh, seg[:,:,1] <= 80)
-    pos = np.logical_and(cell, seg[:,:,0] >= seg[:,:,2])
-    neg = np.logical_xor(cell, pos)
+    Parameters
+    ----------
+    seg : ndarray
+        3D uint8 array (2D image w/ 3 channels) with segmentation probabilities.
+    thresh : int
+        Threshold to use in determining if a pixel should be labeled as positive/negative.
 
-    mask = np.full(seg.shape[0:2], MASK_UNKNOWN, dtype=np.uint8)
-    mask[pos] = MASK_POSITIVE
-    mask[neg] = MASK_NEGATIVE
+    Returns
+    -------
+    ndarray
+        2D uint8 array of mask values with every pixel labeled as unknown, positive, or negative.
+    """
+
+    mask = np.full(seg.shape[0:2], LABEL_UNKNOWN, dtype=np.uint8)
+    for y in range(mask.shape[0]):
+        for x in range(mask.shape[1]):
+            if seg[y, x, 0] + seg[y, x, 2] > thresh and seg[y, x, 1] <= 80:
+                if seg[y, x, 0] >= seg[y, x, 2]:
+                    mask[y, x] = LABEL_POSITIVE
+                else:
+                    mask[y, x] = LABEL_NEGATIVE
 
     return mask
 
 
 @jit(nopython=True)
 def mark_background(mask):
-    """Mask all background pixels by 4-connected region growing unknown boundary pixels."""
+    """
+    Mask all background pixels in-place by 4-connected region growing unknown boundary pixels.
+
+    Parameters
+    ----------
+    mask: ndarray
+        2D uint8 array with pixels labeled as positive, negative, or unknown.
+        After the function executes, the pixels will be labeled as background, positive, negative, or unknown.
+    """
 
     seeds = []
     for i in range(mask.shape[0]):
-        if mask[i, 0] == MASK_UNKNOWN:
+        if mask[i, 0] == LABEL_UNKNOWN:
             seeds.append((i, 0))
-        if mask[i, mask.shape[1]-1] == MASK_UNKNOWN:
+        if mask[i, mask.shape[1]-1] == LABEL_UNKNOWN:
             seeds.append((i, mask.shape[1]-1))
     for j in range(mask.shape[1]):
-        if mask[0, j] == MASK_UNKNOWN:
+        if mask[0, j] == LABEL_UNKNOWN:
             seeds.append((0, j))
-        if mask[mask.shape[0]-1, j] == MASK_UNKNOWN:
+        if mask[mask.shape[0]-1, j] == LABEL_UNKNOWN:
             seeds.append((mask.shape[0]-1, j))
 
     neighbors = [(-1, 0), (1, 0), (0, -1), (0, 1)]
 
     while len(seeds) > 0:
         seed = seeds.pop()
-        if mask[seed] == MASK_UNKNOWN:
-            mask[seed] = MASK_BACKGROUND
+        if mask[seed] == LABEL_UNKNOWN:
+            mask[seed] = LABEL_BACKGROUND
             for n in neighbors:
                 idx = (seed[0] + n[0], seed[1] + n[1])
-                if in_bounds(mask, idx) and mask[idx] == MASK_UNKNOWN:
+                if in_bounds(mask, idx) and mask[idx] == LABEL_UNKNOWN:
                     seeds.append(idx)
 
 
 @jit(nopython=True)
-def compute_cell_classification(mask, marker, size_thresh, marker_thresh, size_thresh_upper = None):
+def compute_cell_mapping(mask, marker, noise_thresh):
     """
-    Compute the mapping of the mask to positive and negative cell classification.
+    Compute the mapping from mask to positive and negative cells.
 
     Parameters
-    ==========
-    mask: 2D uint8 numpy array with pixels labeled as positive, negative, background, or unknown.
-          After the function executes, the pixels will be labeled as background or cell/boundary pos/neg.
-    marker: 2D uint8 numpy array with the restained marker values
-    size_thresh: Lower size threshold in pixels. Only include cells larger than this count.
-    size_thresh_upper: Upper size threshold in pixels, or None. Only include cells smaller than this count.
-    marker_thresh: Classify cell as positive if any marker value within the cell is above this threshold.
+    ----------
+    mask : ndarray
+        2D uint8 array with pixels labeled as positive, negative, background, or unknown.
+        After the function executes, the pixels will be labeled as background or cell.
+    marker : ndarray
+        2D uint8 array with the inferred marker values.
 
     Returns
-    =======
-    Dictionary with the following values:
-        num_total (integer) -- total number of cells in the image
-        num_pos (integer) -- number of positive cells in the image
-        num_neg (integer) -- number of negative calles in the image
-        percent_pos (floating point) -- percentage of positive cells to all cells (IHC score)
+    -------
+    typed.List[tuple] :
+        Cell data as a list of 7-element tuples with the following:
+        [0] - number of pixels in the cell
+        [1] - whether the cell is positive (True) or negative (False)
+        [2] - marker value for the cell
+        [3-4] - first pixel coordinates (x, y) of the cell cluster
+        [5-6] - centroid of the cell (x, y)
     """
 
     neighbors = [(-1, -1), (0, -1), (1, -1), (-1, 0), (1, 0), (-1, 1), (0, 1), (1, 1)]
-    border_neighbors = [(0, -1), (-1, 0), (1, 0), (0, 1)]
-    positive_cell_count, negative_cell_count = 0, 0
+    cells = typed.List()
 
     for y in range(mask.shape[0]):
         for x in range(mask.shape[1]):
-            if mask[y, x] == MASK_POSITIVE or mask[y, x] == MASK_NEGATIVE:
+            if mask[y, x] != LABEL_BACKGROUND and mask[y, x] != LABEL_CELL:
                 seeds = [(y, x)]
-                cell_coords = []
                 count = 1
-                count_posneg = 1 if mask[y, x] != MASK_UNKNOWN else 0
-                count_positive = 1 if mask[y, x] == MASK_POSITIVE else 0
+                count_positive = 1 if mask[y, x] == LABEL_POSITIVE else 0
+                count_negative = 1 if mask[y, x] == LABEL_NEGATIVE else 0
                 max_marker = marker[y, x] if marker is not None else 0
-                mask[y, x] = MASK_CELL
-                cell_coords.append((y, x))
+                mask[y, x] = LABEL_CELL
+                center_y = y
+                center_x = x
 
                 while len(seeds) > 0:
                     seed = seeds.pop()
                     for n in neighbors:
                         idx = (seed[0] + n[0], seed[1] + n[1])
-                        if in_bounds(mask, idx) and (mask[idx] == MASK_POSITIVE or mask[idx] == MASK_NEGATIVE or mask[idx] == MASK_UNKNOWN):
+                        if in_bounds(mask, idx) and mask[idx] != LABEL_BACKGROUND and mask[idx] != LABEL_CELL:
                             seeds.append(idx)
-                            if mask[idx] == MASK_POSITIVE:
+                            if mask[idx] == LABEL_POSITIVE:
                                 count_positive += 1
-                            if mask[idx] != MASK_UNKNOWN:
-                                count_posneg += 1
+                            elif mask[idx] == LABEL_NEGATIVE:
+                                count_negative += 1
                             if marker is not None and marker[idx] > max_marker:
                                 max_marker = marker[idx]
-                            mask[idx] = MASK_CELL
-                            cell_coords.append(idx)
+                            mask[idx] = LABEL_CELL
+                            center_y += idx[0]
+                            center_x += idx[1]
                             count += 1
 
-                if count > size_thresh and (size_thresh_upper is None or count < size_thresh_upper):
-                    if (count_positive/count_posneg) >= 0.5 or max_marker > marker_thresh:
-                        fill_value = MASK_CELL_POSITIVE
-                        border_value = MASK_BOUNDARY_POSITIVE
-                        positive_cell_count += 1
-                    else:
-                        fill_value = MASK_CELL_NEGATIVE
-                        border_value = MASK_BOUNDARY_NEGATIVE
-                        negative_cell_count += 1
-                else:
-                    fill_value = MASK_BACKGROUND
-                    border_value = MASK_BACKGROUND
+                if count > noise_thresh:
+                    center_y = int(round(center_y / count))
+                    center_x = int(round(center_x / count))
+                    positive = True if count_positive >= count_negative else False
+                    cells.append((count, positive, max_marker, x, y, center_x, center_y))
 
-                for coord in cell_coords:
-                    is_boundary = False
-                    for n in border_neighbors:
-                        idx = (coord[0] + n[0], coord[1] + n[1])
-                        if in_bounds(mask, idx) and mask[idx] == MASK_BACKGROUND:
-                            is_boundary = True
-                            break
-                    if is_boundary:
-                        mask[coord] = border_value
-                    else:
-                        mask[coord] = fill_value
-
-    counts = {
-        'num_total': positive_cell_count + negative_cell_count,
-        'num_pos': positive_cell_count,
-        'num_neg': negative_cell_count,
-    }
-    return counts
+    return cells
 
 
-@jit(nopython=True)
-def enlarge_cell_boundaries(mask):
-    neighbors = [(-1, -1), (0, -1), (1, -1), (-1, 0), (1, 0), (-1, 1), (0, 1), (1, 1)]
-    for y in range(mask.shape[0]):
-        for x in range(mask.shape[1]):
-            if mask[y, x] == MASK_BOUNDARY_POSITIVE or mask[y, x] == MASK_BOUNDARY_NEGATIVE:
-                value = MASK_POSITIVE if mask[y, x] == MASK_BOUNDARY_POSITIVE else MASK_NEGATIVE
-                for n in neighbors:
-                    idx = (y + n[0], x + n[1])
-                    if in_bounds(mask, idx) and mask[idx] != MASK_BOUNDARY_POSITIVE and mask[idx] != MASK_BOUNDARY_NEGATIVE:
-                        mask[idx] = value
-    for y in range(mask.shape[0]):
-        for x in range(mask.shape[1]):
-            if mask[y, x] == MASK_POSITIVE:
-                mask[y, x] = MASK_BOUNDARY_POSITIVE
-            elif mask[y, x] == MASK_NEGATIVE:
-                mask[y, x] = MASK_BOUNDARY_NEGATIVE
+def get_cells_info(seg, marker, resolution, noise_thresh, seg_thresh):
+    """
+    Find all cells in the segmentation image that are larger than the noise threshold.
 
+    Parameters
+    ----------
+    seg : Image | ndarray
+        Inferred segmentation map image.
+    marker : Image | ndarray
+        Inferred marker image.
+    resolution: string
+        The resolution/magnification of the original image.  Valid values are '10x', '20x', or '40x'.
+    noise_thresh : int
+        Threshold for tiny noise to ignore (include only cells larger than this value).
+    seg_thresh : int
+        Threshold to use in determining if a pixel should be labeled as positive/negative.
 
-@jit(nopython=True)
-def compute_cell_sizes(mask):
-    neighbors = [(-1, -1), (0, -1), (1, -1), (-1, 0), (1, 0), (-1, 1), (0, 1), (1, 1)]
-    sizes = []
+    Returns
+    -------
+    ndarray :
+        Label mask.
+    typed.List[tuple] :
+        Cell data as a list of 7-element tuples.
+    dict :
+        Calculated default values.
+    """
 
-    for y in range(mask.shape[0]):
-        for x in range(mask.shape[1]):
-            if mask[y, x] == MASK_POSITIVE or mask[y, x] == MASK_NEGATIVE:
-                seeds = [(y, x)]
-                count = 1
-                mask[y, x] = MASK_CELL_POSITIVE if mask[y, x] == MASK_POSITIVE else MASK_CELL_NEGATIVE
+    seg = to_array(seg)
+    if marker is not None:
+        marker = to_array(marker, True)
+    mask = create_posneg_mask(seg, seg_thresh)
+    mark_background(mask)
+    cellsinfo = compute_cell_mapping(mask, marker, noise_thresh)
 
-                while len(seeds) > 0:
-                    seed = seeds.pop()
-                    for n in neighbors:
-                        idx = (seed[0] + n[0], seed[1] + n[1])
-                        if in_bounds(mask, idx) and (mask[idx] == MASK_POSITIVE or mask[idx] == MASK_NEGATIVE or mask[idx] == MASK_UNKNOWN):
-                            seeds.append(idx)
-                            if mask[idx] == MASK_POSITIVE:
-                                mask[idx] = MASK_CELL_POSITIVE
-                            elif mask[idx] == MASK_NEGATIVE:
-                                mask[idx] = MASK_CELL_NEGATIVE
-                            else:
-                                mask[idx] = MASK_CELL
-                            count += 1
+    defaults = {}
+    sizes = np.zeros(len(cellsinfo), dtype=np.int64)
+    for i in range(len(cellsinfo)):
+        sizes[i] = cellsinfo[i][0]
+    defaults['size_thresh'] = calculate_default_size_threshold(sizes, resolution)
+    if marker is not None:
+        defaults['marker_thresh'] = calculate_default_marker_threshold(marker)
 
-                sizes.append(count)
-
-    return sizes
+    return mask, cellsinfo, defaults
 
 
 @jit(nopython=True)
 def create_kde(values, count, bandwidth = 1.0):
+    """
+    Create Gaussian kernel density estimate (KDE) for values with count number of bins.
+
+    Parameters
+    ----------
+    values : list
+        Input values.
+    count : int
+        Number of bins for KDE.
+    bandwidth: float
+        Bandwidth (smoothing parameter) for KDE.
+
+    Returns
+    -------
+    ndarray :
+        Kernel density estimate.
+    float :
+        Step size.
+    """
+
     gaussian_denom_inv = 1 / math.sqrt(2 * math.pi);
     max_value = max(values) + 1;
     step = max_value / count;
@@ -360,14 +359,26 @@ def create_kde(values, count, bandwidth = 1.0):
     return kde, step
 
 
-def calc_default_size_thresh(mask, resolution):
-    sizes = compute_cell_sizes(mask)
-    mask[mask == MASK_CELL_POSITIVE] = MASK_POSITIVE
-    mask[mask == MASK_CELL_NEGATIVE] = MASK_NEGATIVE
-    mask[mask == MASK_CELL] = MASK_UNKNOWN
+@jit(nopython=True)
+def calculate_default_size_threshold(cell_sizes, resolution='40x'):
+    """
+    Calculate a default size threshold to exclude small cells.
 
-    if len(sizes) > 0:
-        kde, step = create_kde(np.sqrt(sizes), 500)
+    Parameters
+    ----------
+    cell_sizes : ndarray
+        1D array of cell sizes.
+    resolution : string
+        The resolution/magnification of the original image.  Valid values are '10x', '20x', or '40x'.
+
+    Returns
+    -------
+    int :
+        Default size threshold.
+    """
+
+    if cell_sizes.shape[0] > 1:
+        kde, step = create_kde(np.sqrt(cell_sizes), 500)
         idx = 1
         for i in range(1, kde.shape[0]-1):
             if kde[i] < kde[i-1] and kde[i] < kde[i+1]:
@@ -392,49 +403,845 @@ def calc_default_size_thresh(mask, resolution):
         return 0
 
 
-def calc_default_marker_thresh(marker):
-    if marker is not None:
-        nonzero = marker[marker != 0]
-        marker_range = (round(np.percentile(nonzero, 0.1)), round(np.percentile(nonzero, 99.9))) if nonzero.shape[0] > 0 else (0, 0)
-        return round((marker_range[1] - marker_range[0]) * 0.9) + marker_range[0]
+def calculate_stain_range(stain):
+    """
+    Calculate the range of the 99.9 percentile of non-zero pixels in the stain image.
+
+    Parameters
+    ----------
+    stain : ndarray
+        2D uint8 array (image).
+
+    Returns
+    -------
+    tuple[int] :
+        2-element tuple with 0.1 and 99.9 percentile values.
+    """
+
+    nonzero = stain[stain != 0]
+    if nonzero.shape[0] > 0:
+        return (round(np.percentile(nonzero, 0.1)), round(np.percentile(nonzero, 99.9)))
     else:
-        return 0
+        return (0, 0)
 
 
-def compute_results(orig, seg, marker, resolution=None, seg_thresh=150, size_thresh='auto', marker_thresh='auto', size_thresh_upper=None):
-    mask = create_posneg_mask(seg, seg_thresh)
-    mark_background(mask)
+def calculate_default_marker_threshold(marker):
+    """
+    Calculate a default threshold for a marker image as 90% of the 99.9 percentile range.
 
-    if size_thresh == 'auto':
-        size_thresh = calc_default_size_thresh(mask, resolution)
+    Parameters
+    ----------
+    marker : ndarray
+        2D uint8 array (image).
+
+    Results
+    -------
+    int :
+        Default marker threshold.
+    """
+
+    marker_range = calculate_stain_range(marker)
+    return round((marker_range[1] - marker_range[0]) * 0.9) + marker_range[0]
+
+
+@jit(nopython=True)
+def get_cell_boundary(mask, x, y):
+    """
+    Get the boundary contour pixels for a cell, and also the bounding box.
+    The provided starting (x, y) pixel must be the first pixel encountered
+    from the top left, whether found by searching via rows or columns.
+
+    Parameters
+    ----------
+    mask : ndarray
+        2D uint8 ndarray of background and cell labels
+    x : int
+        x-coordinate of the first pixel of the cell
+    y : int
+        y-coordinate of the first pixel of the cell
+
+    Returns
+    -------
+    list :
+        Bounding box of the cell as a list of two 2-element tuples.
+    list :
+        All boundary pixels (x, y) going clockwise from first point.
+    """
+
+    w = mask.shape[1]
+    h = mask.shape[0]
+
+    if not in_bounds(mask, (y, x)) or mask[y, x] == LABEL_BACKGROUND:
+        return None, None
+
+    '''
+    In normal xy coordinates, check neighbors clockwise in the following order:
+     0 1 2
+     7 - 3
+     6 5 4
+    List neighbors in xy coordinates, but xy are switched to yx for numpy array access.
+    '''
+    neighbors = [(-1, -1), (0, -1), (1, -1), (1, 0), (1, 1), (0, 1), (-1, 1), (-1, 0)] # (dx, dy)
+    neighbors *= 2
+
+    boundary = [(x, y)]
+    min_x = x
+    min_y = y
+    max_x = x
+    max_y = y
+
+    # Go counter-clockwise to find previous pixel
+    idx = 6
+    while idx >= 0:
+        nx = x + neighbors[idx][0]
+        ny = y + neighbors[idx][1]
+        if in_bounds(mask, (ny, nx)) and mask[ny, nx] != LABEL_BACKGROUND:
+            break
+        idx -= 1
+    if idx < 0:
+        return [(x, y), (x, y)], [(x, y)]
+
+    px = x + neighbors[idx][0]
+    py = y + neighbors[idx][1]
+    boundary = [(px, py), (x, y)]
+
+    # Go clockwise to get border pixels in order
+    while True:
+        dx = px - x
+        dy = py - y
+        idx = neighbors.index((dx, dy)) + 1
+        while True:
+            nx = x + neighbors[idx][0]
+            ny = y + neighbors[idx][1]
+            if in_bounds(mask, (ny, nx)) and mask[ny, nx] != LABEL_BACKGROUND:
+                break
+            idx += 1
+        px = x
+        py = y
+        x = nx
+        y = ny
+        boundary.append((x, y))
+
+        if x < min_x:
+            min_x = x
+        elif x > max_x:
+            max_x = x
+        if y < min_y:
+            min_y = y
+        elif y > max_y:
+            max_y = y
+
+        if px == boundary[0][0] and py == boundary[0][1] and x == boundary[1][0] and y == boundary[1][1]:
+            break
+
+    return [(min_x, min_y), (max_x, max_y)], boundary[1:-1]
+
+
+def make_simple_contour(points):
+    """
+    Make a simplified version of a contour by removing redundant points within
+    straight lines (i.e., each straight line segment will be reduced to contain
+    only the first and last point for that segment).  It is assumed that the
+    vectors between points are all one of the eight pixel neighbor directions.
+    This means that either one of the x- or y-direction must be zero, or if
+    both values are non-zero then they must be the same (i.e., [1,0], [0,2],
+    [2,2], and [3,3] are vall valid direction vectors, but [1,2] is not).
+    The input parameter of contour points must contain at least one point.
+
+    Parameters
+    ----------
+    points : list
+        Contour of boundary points (x, y).
+
+    Returns
+    -------
+    list :
+        Simplified contour of boundary points (x, y).
+    """
+
+    # always keep first point
+    simple = [(points[0][0], points[0][1])]
+
+    # if only one point in contour, then done
+    if len(points) == 1:
+        return simple
+
+    # for all middle points (exclude first and last)
+    for i in range(1, len(points) - 1):
+        dx0 = points[i][0] - points[i-1][0]
+        dy0 = points[i][1] - points[i-1][1]
+        dx1 = points[i+1][0] - points[i][0]
+        dy1 = points[i+1][1] - points[i][1]
+        same_dx = (dx0 == dx1) or (dx0 > 0 and dx1 > 0) or (dx0 < 0 and dx1 < 0)
+        same_dy = (dy0 == dy1) or (dy0 > 0 and dy1 > 0) or (dy0 < 0 and dy1 < 0)
+        if not same_dx or not same_dy:
+            simple.append((points[i][0], points[i][1]))
+
+    # for last point (calculate p[n]-p[n-1] and p[0]-p[n])
+    dx0 = points[-1][0] - points[-2][0]
+    dy0 = points[-1][1] - points[-2][1]
+    dx1 = points[0][0] - points[-1][0]
+    dy1 = points[0][1] - points[-1][1]
+    same_dx = (dx0 == dx1) or (dx0 > 0 and dx1 > 0) or (dx0 < 0 and dx1 < 0)
+    same_dy = (dy0 == dy1) or (dy0 > 0 and dy1 > 0) or (dy0 < 0 and dy1 < 0)
+    if not same_dx or not same_dy:
+        simple.append((points[-1][0], points[-1][1]))
+
+    return simple
+
+
+def make_full_contour(points):
+    """
+    Convert a simplified contour to a complete pixel-by-pixel contour
+    (i.e., every point is an 8-neighbor of the previous point).  It is
+    assumed that vectors between points are all one of the eight pixel
+    neighbor directions.  The input parameter of contour points must
+    contain at least one point.
+
+    Parameters
+    ----------
+    points : list
+        Contour of boundary points (x, y).
+
+    Returns
+    -------
+    list :
+        Full contour of boundary points (x, y).
+    """
+
+    # start with first point
+    full = [(points[0][0], points[0][1])]
+
+    # for all remaining points:
+    for i in range(1, len(points)):
+
+        # calculate direction from last full point to current input point
+        dx = points[i][0] - full[-1][0]
+        dy = points[i][1] - full[-1][1]
+        dx = 1 if dx > 0 else (-1 if dx < 0 else 0)
+        dy = 1 if dy > 0 else (-1 if dy < 0 else 0)
+
+        # add direction to last full point until reach current input point
+        while full[-1][0] != points[i][0] or full[-1][1] != points[i][1]:
+            full.append((full[-1][0] + dx, full[-1][1] + dy))
+
+    # calculate direction from last full point until first point
+    dx = full[0][0] - full[-1][0]
+    dy = full[0][1] - full[-1][1]
+    dx = 1 if dx > 0 else (-1 if dx < 0 else 0)
+    dy = 1 if dy > 0 else (-1 if dy < 0 else 0)
+
+    # add direction to last full point until reach first point (avoid duplicate)
+    while full[-1][0] + dx != full[0][0] or full[-1][1] + dy != full[0][1]:
+        full.append((full[-1][0] + dx, full[-1][1] + dy))
+
+    return full
+
+
+def to_base92(values, min_len=1):
+    """
+    Convert integer values to base92, offset by 35 for printable ASCII values
+    (i.e., output characters for [0-91] are in the range [35-126]).
+    All encodings will have the same number of characters, of at least min_len
+    (i.e., smaller in length encodings will be padded with 35).
+
+    Parameters
+    ----------
+    values : int | list[int] | tuple[int]
+        The integer value(s) to a base92 ASCII encoding.
+    min_len : int
+        The minimum number of characters for the base92 ASCII encoding of each value.
+
+    Returns
+    -------
+    string | list[string] :
+        The converted value(s).
+    """
+
+    multi = type(values) is list or type(values) is tuple
+    if not multi:
+        values = [values]
+
+    results = []
+    for val in values:
+        res = ''
+        while val > 0:
+            res += chr((val % 92) + 35)
+            val //= 92
+        results.append(res)
+
+    max_len = max(len(r) for r in results)
+    fixed_len = max_len if max_len > min_len else min_len
+
+    for i in range(len(results)):
+        while len(results[i]) < fixed_len:
+            results[i] += chr(35)
+        results[i] = results[i][::-1]
+
+    if not multi:
+        results = results[0]
+    return results
+
+
+def from_base92(val):
+    """
+    Convert from base92 ASCII encoding to integer value.
+
+    Parameters
+    ----------
+    val : string
+        The base92 ASCII encoded value.
+
+    Returns
+    -------
+    int :
+        The converted value.
+    """
+
+    res = 0
+    for v in val:
+        res *= 92
+        res += (ord(v) - 35)
+    return res
+
+
+def encode_cell_data_v4(data):
+    """
+    Encode as v4 the provided cell data to string.
+
+    Parameters
+    ----------
+    data : dict
+        Dictionary of cell data.
+
+    Returns
+    -------
+    string :
+        Encoded cell data as a single ASCII string.
+    """
+
+    cell = '' # encoded cell data as string
+
+    # encode cell size (in pixels)
+    size = to_base92(data['size'])
+    size_len = len(size)
+    cell += size
+
+    # encode cell classification (pos/neg) and marker value
+    positive = int(data['positive'])
+    marker = data['marker']
+    classification = (marker * 2) + positive
+    cell += to_base92(classification, 2)
+
+    # encode anchor point (bbox top left) and extent (bbox bottom right)
+    topleft = to_base92(data['bbox'][0])
+    topleft_len = len(topleft[0])
+    cell += topleft[0]
+    cell += topleft[1]
+
+    # encode extent (bbox bottom right), centroid, and first boundary contour point
+    # as offsets from the previously encoded anchor point (bbox top left)
+    x = data['bbox'][0][0]
+    y = data['bbox'][0][1]
+    offsets = [*data['bbox'][1], *data['centroid'], *data['boundary'][0]]
+    for j in range(0, len(offsets), 2):
+        offsets[j] -= x
+        offsets[j+1] -= y
+    offsets = to_base92(offsets)
+    offsets_len = len(offsets[0])
+    cell += offsets[0]
+    cell += offsets[1]
+    cell += offsets[2]
+    cell += offsets[3]
+    cell += offsets[4]
+    cell += offsets[5]
+
+    # encode number of chars for variable length encodations and prepend to cell string
+    encoded_lens = ((size_len - 1) * 16) + ((topleft_len - 1) * 4) + (offsets_len - 1)
+    encoded_lens = chr(encoded_lens + 35)
+    cell = encoded_lens + cell
+
+    # encode remaining boundary contour points using Freeman chain code
+    # Freeman chain code:
+    #   3  2  1
+    #    \ | /
+    #   4-- --0
+    #    / | \
+    #   5  6  7
+    boundary = ''
+    for j in range(1, len(data['boundary'])):
+        dx = data['boundary'][j][0] - data['boundary'][j-1][0]
+        dy = data['boundary'][j][1] - data['boundary'][j-1][1]
+        if dx >= 1 and dy == 0:
+            direction = 0
+        elif dx >= 1 and dy <= -1:
+            direction = 1
+        elif dx == 0 and dy <= -1:
+            direction = 2
+        elif dx <= -1 and dy <= -1:
+            direction = 3
+        elif dx <= -1 and dy == 0:
+            direction = 4
+        elif dx <= -1 and dy >= 1:
+            direction = 5
+        elif dx == 0 and dy >= 1:
+            direction = 6
+        elif dx >= 1 and dy >= 1:
+            direction = 7
+        else: # this should not (cannot) happen, so if it does, then exit
+            exit()
+        distance = max(abs(dx), abs(dy))
+        if distance == 0: # this should not (cannot) happen, but if duplicate point, then skip
+            continue
+        while distance > 10:
+            encoded = (10 * 8) + direction
+            boundary += chr(encoded + 35)
+            distance -= 10
+        encoded = (distance * 8) + direction
+        boundary += chr(encoded + 35)
+    cell += boundary
+
+    return cell
+
+
+def decode_cell_data_v4(cell):
+    """
+    Decode v4 encoded cell string and return dictionary of cell data.
+
+    Parameters
+    ----------
+    cell : string
+        Encoded cell data as a single ASCII string.
+
+    Returns
+    -------
+    dict :
+        Dictionary with the decoded cell data.
+    """
+
+    data = {} # decoded cell data
+
+    # decode number of chars for variable length encodations
+    n = ord(cell[0]) - 35
+    ns = (n // 16) + 1      # num chars for cell size
+    na = ((n // 4) % 4) + 1 # num chars for anchor coordinates
+    no = (n % 4) + 1        # num chars for offset coordinates
+
+    # decode cell size (in pixels)
+    data['size'] = from_base92(cell[1:1+ns])
+
+    # decode cell classification (pos/neg) and marker value
+    classification = from_base92(cell[1+ns:3+ns])
+    data['positive'] = bool(classification % 2)
+    data['marker'] = classification // 2
+
+    # decode anchor point (bbox top left) and extent (bbox bottom right)
+    x = from_base92(cell[3+ns:3+ns+na])
+    y = from_base92(cell[3+ns+na:3+ns+2*na])
+    ex = x + from_base92(cell[3+ns+2*na:3+ns+2*na+no])
+    ey = y + from_base92(cell[3+ns+2*na+no:3+ns+2*na+2*no])
+    data['bbox'] = [(x, y), (ex, ey)]
+
+    # decode centroid point
+    cx = x + from_base92(cell[3+ns+2*na+2*no:3+ns+2*na+3*no])
+    cy = y + from_base92(cell[3+ns+2*na+3*no:3+ns+2*na+4*no])
+    data['centroid'] = (cx, cy)
+
+    # decode first boundary contour points
+    bx = x + from_base92(cell[3+ns+2*na+4*no:3+ns+2*na+5*no])
+    by = y + from_base92(cell[3+ns+2*na+5*no:3+ns+2*na+6*no])
+    data['boundary'] = [(bx, by)]
+
+    # directions using Freeman chain code
+    freeman = [(1,0), (1,-1), (0,-1), (-1,-1), (-1,0), (-1,1), (0,1), (1,1)]
+
+    # decode remaining boundary contour points
+    prev_direction = None
+    for c in cell[3+ns+2*na+6*no:]:
+        point = ord(c) - 35
+        distance = point // 8
+        direction = freeman[point % 8]
+        movement = (direction[0]*distance, direction[1]*distance)
+        px = data['boundary'][-1][0] + movement[0]
+        py = data['boundary'][-1][1] + movement[1]
+        if direction == prev_direction:
+            data['boundary'].pop()
+        data['boundary'].append((px, py))
+        prev_direction = direction
+
+    return data
+
+
+@jit(nopython=True)
+def create_cell_classification(mask, cellsinfo,
+                               size_thresh=0,
+                               marker_thresh=None,
+                               size_thresh_upper=None):
+    """
+    Create final cell classification in-place for the mask and
+    calculate counts for positive and negative cell counts.
+
+    Parameters
+    ----------
+    mask : ndarray
+        2D uint8 array label map.
+    cellsinfo : list
+        Information about each cell found from the segmentation.
+    size_thresh : int
+        Include only cells larger than this size.
+    marker_thresh : int
+        Make cell positive if marker value is above this threshold (override original classification).
+    size_thresh_upper : int
+        Include only cells smaller than this size.
+
+    Results
+    -------
+    dict :
+        Dictionary with the counts of positive, negative, and total cells.
+    """
+
+    neighbors = [(-1, -1), (0, -1), (1, -1), (-1, 0), (1, 0), (-1, 1), (0, 1), (1, 1)]
+    border_neighbors = [(0, -1), (-1, 0), (1, 0), (0, 1)]
+    num_pos, num_neg = 0, 0
     if marker_thresh is None:
-        marker_thresh = 0
-        marker = None
-    elif marker_thresh == 'auto':
-        marker_thresh = calc_default_marker_thresh(marker)
+        marker_thresh = 255
 
-    counts = compute_cell_classification(mask, marker, size_thresh, marker_thresh, size_thresh_upper)
+    for cell in cellsinfo:
+        if cell[0] > size_thresh and (size_thresh_upper is None or cell[0] < size_thresh_upper):
+            is_pos = True if cell[1] or cell[2] > marker_thresh else False
+            if is_pos:
+                label = LABEL_POSITIVE
+                label_border = LABEL_BORDER_POS
+                num_pos += 1
+            else:
+                label = LABEL_NEGATIVE
+                label_border = LABEL_BORDER_NEG
+                num_neg += 1
+
+            x = cell[3]
+            y = cell[4]
+            mask[y,x] = label_border
+            seeds = [(y, x)]
+
+            while len(seeds) > 0:
+                seed = seeds.pop()
+                for n in neighbors:
+                    idx = (seed[0] + n[0], seed[1] + n[1])
+                    if in_bounds(mask, idx) and mask[idx] == LABEL_CELL:
+                        seeds.append(idx)
+                        is_boundary = False
+                        for n in border_neighbors:
+                            idx2 = (idx[0] + n[0], idx[1] + n[1])
+                            if in_bounds(mask, idx2) and mask[idx2] == LABEL_BACKGROUND:
+                                is_boundary = True
+                                break
+                        if is_boundary:
+                            mask[idx] = label_border
+                        else:
+                            mask[idx] = label
+
+    num_total = num_pos + num_neg
+    return {
+        'num_total': num_total,
+        'num_pos': num_pos,
+        'num_neg': num_neg,
+    }
+
+
+@jit(nopython=True)
+def enlarge_cell_boundaries(mask):
+    """
+    Enlarge cell boundaries in-place in mask by one pixel in each direction.
+
+    Parameters
+    ----------
+    mask : ndarray
+        2D uint8 label map.
+    """
+
+    neighbors = [(-1, -1), (0, -1), (1, -1), (-1, 0), (1, 0), (-1, 1), (0, 1), (1, 1)]
+
+    for y in range(mask.shape[0]):
+        for x in range(mask.shape[1]):
+            if mask[y, x] == LABEL_BORDER_POS or mask[y, x] == LABEL_BORDER_NEG:
+                value = LABEL_BORDER_POS2 if mask[y, x] == LABEL_BORDER_POS else LABEL_BORDER_NEG2
+                for n in neighbors:
+                    idx = (y + n[0], x + n[1])
+                    if in_bounds(mask, idx) and mask[idx] != LABEL_BORDER_POS and mask[idx] != LABEL_BORDER_NEG:
+                        mask[idx] = value
+
+    for y in range(mask.shape[0]):
+        for x in range(mask.shape[1]):
+            if mask[y, x] == LABEL_BORDER_POS2:
+                mask[y, x] = LABEL_BORDER_POS
+            elif mask[y, x] == LABEL_BORDER_NEG2:
+                mask[y, x] = LABEL_BORDER_NEG
+
+
+@jit(nopython=True)
+def create_final_images(overlay, mask):
+    """
+    Create the final overlay (in-place) and refined images from the mask.
+    The 'overlay' parameter is the image on which to create the overlay,
+    which will be done in-place.
+
+    Parameters
+    ----------
+    overlay : ndarray
+        3D uint8 array (2D image of 3 channels).
+        Generally, a copy of the original input image.
+    mask : ndarray
+        2D uint8 label map.
+
+    Returns
+    -------
+    ndarray :
+        3D uint8 array (2D image of 3 channels) containing the overlaid image.
+    ndarray :
+        3D uint8 array (2D image of 3 channels) containing the refined segmentation image.
+    """
+
+    refined = np.zeros_like(overlay)
+
+    for y in range(mask.shape[0]):
+        for x in range(mask.shape[1]):
+            if mask[y, x] == LABEL_BORDER_POS:
+                overlay[y, x] = (255, 0, 0)
+                refined[y, x, 1] = 255
+            elif mask[y, x] == LABEL_BORDER_NEG:
+                overlay[y, x] = (0, 0, 255)
+                refined[y, x, 1] = 255
+            elif mask[y, x] == LABEL_POSITIVE:
+                refined[y, x, 0] = 255
+            elif mask[y, x] == LABEL_NEGATIVE:
+                refined[y, x, 2] = 255
+
+    return overlay, refined
+
+
+@jit(nopython=True)
+def fill_cells(mask):
+    """
+    For a mask with cell outlines, fill in the center of the cells in-place.
+    The cell outlines must surround cell entirely, including image border pixels.
+
+    Parameters
+    ----------
+    mask : ndarray
+        2D uint8 label map.
+    """
+
+    for y in range(mask.shape[0]):
+        for x in range(1, mask.shape[1]):
+            if mask[y, x] == LABEL_UNKNOWN:
+                if mask[y, x-1] == LABEL_BORDER_POS or mask[y, x-1] == LABEL_POSITIVE:
+                    mask[y, x] = LABEL_POSITIVE
+                else:
+                    mask[y, x] = LABEL_NEGATIVE
+
+
+def compute_cell_results(seg, marker, resolution, version=3,
+                         seg_thresh=DEFAULT_SEG_THRESH,
+                         noise_thresh=DEFAULT_NOISE_THRESH):
+    """
+    Perform postprocessing to compute individual cell results.
+
+    Parameters
+    ----------
+    seg : Image | ndarray
+        Inferred segmentation map image.
+    marker : Image | ndarray
+        Inferred marker image.
+    resolution : string
+        The resolution/magnification of the original image.  Valid values are '10x', '20x', or '40x'.
+    version : int
+        Version of the cell data (valid values are 3 and 4).
+    seg_thresh : int
+        Threshold to use in determining if a pixel should be labeled as positive/negative.
+    noise_thresh : int
+        Threshold for tiny noise to ignore (include only cells larger than this value).
+
+    Returns
+    -------
+    dict :
+        Individual cell data and other associated values.
+    """
+
+    if version not in [3, 4]:
+        warnings.warn('Invalid cell data version provided, defaulting to version 3.')
+        version = 3
+
+    mask, cellsinfo, defaults = get_cells_info(seg, marker, resolution, noise_thresh, seg_thresh)
+
+    cells = []
+    for cell in cellsinfo:
+        bbox, boundary = get_cell_boundary(mask, cell[3], cell[4])
+        data = {
+            'size': cell[0],
+            'positive': cell[1],
+            'marker': cell[2],
+            'bbox': bbox,
+            'centroid': (cell[5], cell[6]),
+            'boundary': make_simple_contour(boundary),
+        }
+        if version == 4:
+            data = encode_cell_data_v4(data)
+        cells.append(data)
+
+    results = {
+        'cells': cells,
+        'settings': {
+            'default_marker_thresh': defaults['marker_thresh'] if 'marker_thresh' in defaults else None,
+            'default_size_thresh': defaults['size_thresh'],
+            'noise_thresh': noise_thresh,
+            'seg_thresh': seg_thresh,
+        },
+        'dataVersion': version,
+    }
+
+    return results
+
+
+def compute_final_results(orig, seg, marker, resolution,
+                          size_thresh='default',
+                          marker_thresh=None,
+                          size_thresh_upper=None,
+                          seg_thresh=DEFAULT_SEG_THRESH,
+                          noise_thresh=DEFAULT_NOISE_THRESH):
+    """
+    Perform postprocessing to compute final count and image results.
+
+    Parameters
+    ----------
+    orig : Image | ndarray
+        Original input image.
+    seg : Image | ndarray
+        Inferred segmentation map image.
+    marker : Image | ndarray
+        Inferred marker image.
+    resolution : string
+        The resolution/magnification of the original image.  Valid values are '10x', '20x', or '40x'.
+    size_thresh : int
+        Include only cells larger than this size.
+    marker_thresh : int
+        Make cell positive if marker value is above this threshold (override original classification).
+    size_thresh_upper : int
+        Include only cells smaller than this size.
+    seg_thresh : int
+        Threshold to use in determining if a pixel should be labeled as positive/negative.
+    noise_thresh : int
+        Threshold for tiny noise to ignore (include only cells larger than this value).
+
+    Returns
+    -------
+    ndarray :
+        3D uint8 array (2D image of 3 channels) containing the overlaid image.
+    ndarray :
+        3D uint8 array (2D image of 3 channels) containing the refined segmentation image.
+    dict :
+        Dictionary with scoring and settings information.
+    """
+
+    mask, cellsinfo, defaults = get_cells_info(seg, marker, resolution, noise_thresh, seg_thresh)
+
+    if size_thresh is None:
+        size_thresh = 0
+    elif size_thresh == 'default':
+        size_thresh = defaults['size_thresh']
+    if marker_thresh == 'default':
+        marker_thresh = defaults['marker_thresh']
+
+    counts = create_cell_classification(mask, cellsinfo, size_thresh, marker_thresh, size_thresh_upper)
     enlarge_cell_boundaries(mask)
+    overlay, refined = create_final_images(np.array(orig), mask)
 
     scoring = {
         'num_total': counts['num_total'],
         'num_pos': counts['num_pos'],
         'num_neg': counts['num_neg'],
         'percent_pos': round(counts['num_pos'] / counts['num_total'] * 100, 1) if counts['num_pos'] > 0 else 0,
-        'prob_thresh': seg_thresh,
+        'seg_thresh': seg_thresh,
         'size_thresh': size_thresh,
         'size_thresh_upper': size_thresh_upper,
         'marker_thresh': marker_thresh if marker is not None else None,
     }
 
-    overlay = np.copy(orig)
-    overlay[mask == MASK_BOUNDARY_POSITIVE] = (255, 0, 0)
-    overlay[mask == MASK_BOUNDARY_NEGATIVE] = (0, 0, 255)
+    return overlay, refined, scoring
 
-    refined = np.zeros_like(seg)
-    refined[mask == MASK_CELL_POSITIVE, 0] = 255
-    refined[mask == MASK_CELL_NEGATIVE, 2] = 255
-    refined[mask == MASK_BOUNDARY_POSITIVE, 1] = 255
-    refined[mask == MASK_BOUNDARY_NEGATIVE, 1] = 255
+
+def cells_to_final_results(data, orig,
+                           size_thresh='default',
+                           marker_thresh=None,
+                           size_thresh_upper=None):
+    """
+    Compute final count and image results from previously postprocessed cell results.
+
+    Parameters
+    ----------
+    data : dict
+        Individual cell data and associated values generated by the 'compute_cell_results' function.
+    orig : Image | ndarray
+        Original input image.
+    size_thresh : int
+        Include only cells larger than this size.
+    marker_thresh : int
+        Make cell positive if marker value is above this threshold (override original classification).
+    size_thresh_upper : int
+        Include only cells smaller than this size.
+
+    Returns
+    -------
+    ndarray :
+        3D uint8 array (2D image of 3 channels) containing the overlaid image.
+    ndarray :
+        3D uint8 array (2D image of 3 channels) containing the refined segmentation image.
+    dict :
+        Dictionary with scoring and settings information.
+    """
+
+    orig = np.array(orig)
+    mask = np.full(orig.shape[0:2], LABEL_UNKNOWN, dtype=np.uint8)
+    num_pos, num_neg = 0, 0
+
+    if size_thresh is None:
+        size_thresh = 0
+    elif size_thresh == 'default':
+        size_thresh = data['settings']['default_size_thresh']
+    if marker_thresh == 'default':
+        marker_thresh = data['settings']['default_marker_thresh']
+
+    for cell in data['cells']:
+        if data['dataVersion'] == 4:
+            c = decode_cell_data_v4(cell)
+        else:
+            c = cell
+        if c['size'] > size_thresh and (size_thresh_upper is None or c['size'] < size_thresh_upper):
+            if c['positive'] or (marker_thresh is not None and c['marker'] > marker_thresh):
+                num_pos += 1
+                label = LABEL_BORDER_POS
+            else:
+                num_neg += 1
+                label = LABEL_BORDER_NEG
+            border = make_full_contour(c['boundary'])
+            for b in border:
+                mask[b[1], b[0]] = label
+
+    mark_background(mask)
+    fill_cells(mask)
+
+    enlarge_cell_boundaries(mask)
+    overlay, refined = create_final_images(np.array(orig), mask)
+
+    num_total = num_pos + num_neg
+    scoring = {
+        'num_total': num_total,
+        'num_pos': num_pos,
+        'num_neg': num_neg,
+        'percent_pos': round(num_pos / num_total * 100, 1) if num_pos > 0 else 0,
+        'seg_thresh': data['settings']['seg_thresh'],
+        'size_thresh': size_thresh,
+        'size_thresh_upper': size_thresh_upper,
+        'marker_thresh': marker_thresh,
+    }
 
     return overlay, refined, scoring

--- a/deepliif/scripts/train.py
+++ b/deepliif/scripts/train.py
@@ -52,7 +52,7 @@ def set_seed(seed=0,rank=None):
         print(f'not using deterministic training')
         return False
 
-
+        
 @click.command()
 @click.option('--dataroot', required=True, type=str,
               help='path to images (should have subfolders trainA, trainB, valA, valB, etc)')
@@ -82,6 +82,8 @@ def set_seed(seed=0,rank=None):
               help='network initialization [normal | xavier | kaiming | orthogonal]')
 @click.option('--init-gain', default=0.02, help='scaling factor for normal, xavier and orthogonal.')
 @click.option('--no-dropout', is_flag=True, help='no dropout for the generator')
+@click.option('--upsample', default='convtranspose', help='use upsampling instead of convtranspose [convtranspose | resize_conv | pixel_shuffle]')
+@click.option('--label-smoothing', type=float,default=0.0, help='label smoothing factor to prevent the discriminator from being too confident')
 # dataset parameters
 @click.option('--direction', default='AtoB', help='AtoB or BtoA')
 @click.option('--serial-batches', is_flag=True,
@@ -120,7 +122,9 @@ def set_seed(seed=0,rank=None):
 @click.option('--optimizer', type=str, default='adam',
               help='optimizer from torch.optim to use, applied to both generators and discriminators [adam | sgd | adamw | ...]; the current parameters however are set up for adam, so other optimziers may encounter issue')
 @click.option('--beta1', default=0.5, help='momentum term of adam')
-@click.option('--lr', default=0.0002, help='initial learning rate for adam')
+#@click.option('--lr', default=0.0002, help='initial learning rate for adam')
+@click.option('--lr-g', default=0.0002, help='initial learning rate for generator adam optimizer')
+@click.option('--lr-d', default=0.0002, help='initial learning rate for discriminator adam optimizer')
 @click.option('--lr-policy', default='linear',
               help='learning rate policy. [linear | step | plateau | cosine]')
 @click.option('--lr-decay-iters', type=int, default=50,
@@ -169,11 +173,11 @@ def set_seed(seed=0,rank=None):
               help='debug mode, limits the number of data points per epoch to a small value')
 @click.option('--debug-data-size', default=10, type=int, help='data size per epoch used in debug mode; due to batch size, the epoch will be passed once the completed no. data points is greater than this value (e.g., for batch size 3, debug data size 10, the effective size used in training will be 12)')
 def train(dataroot, name, gpu_ids, checkpoints_dir, input_nc, output_nc, ngf, ndf, net_d, net_g,
-          n_layers_d, norm, init_type, init_gain, no_dropout, direction, serial_batches, num_threads,
+          n_layers_d, norm, init_type, init_gain, no_dropout, upsample, label_smoothing, direction, serial_batches, num_threads,
           batch_size, load_size, crop_size, max_dataset_size, preprocess, no_flip, display_winsize, epoch, load_iter,
           verbose, lambda_l1, is_train, display_freq, display_ncols, display_id, display_server, display_env,
           display_port, update_html_freq, print_freq, no_html, save_latest_freq, save_epoch_freq, save_by_iter,
-          continue_train, epoch_count, phase, lr_policy, n_epochs, n_epochs_decay, optimizer, beta1, lr, lr_decay_iters,
+          continue_train, epoch_count, phase, lr_policy, n_epochs, n_epochs_decay, optimizer, beta1, lr_g, lr_d, lr_decay_iters,
           remote, remote_transfer_cmd, seed, dataset_mode, padding, model, seg_weights, loss_weights_g, loss_weights_d,
           modalities_no, seg_gen, net_ds, net_gs, gan_mode, gan_mode_s, local_rank, with_val, debug, debug_data_size):
     """General-purpose training script for multi-task image-to-image translation.
@@ -187,7 +191,7 @@ def train(dataroot, name, gpu_ids, checkpoints_dir, input_nc, output_nc, ngf, nd
     plot, and save models.The script supports continue/resume training.
     Use '--continue_train' to resume your previous training.
     """
-    assert model in ['DeepLIIF','DeepLIIFExt','SDG'], f'model class {model} is not implemented'
+    assert model in ['DeepLIIF','DeepLIIFExt','SDG','CycleGAN'], f'model class {model} is not implemented'
     if model == 'DeepLIIF':
         seg_no = 1
     elif model == 'DeepLIIFExt':
@@ -195,9 +199,12 @@ def train(dataroot, name, gpu_ids, checkpoints_dir, input_nc, output_nc, ngf, nd
             seg_no = modalities_no
         else:
             seg_no = 0
-    else: # SDG
+    else: # SDG, CycleGAN
         seg_no = 0
         seg_gen = False
+    
+    if model == 'CycleGAN':
+        dataset_mode = "unaligned"
     
     if optimizer != 'adam':
         print(f'Optimizer torch.optim.{optimizer} is not tested. Be careful about the parameters of the optimizer.')
@@ -232,22 +239,53 @@ def train(dataroot, name, gpu_ids, checkpoints_dir, input_nc, output_nc, ngf, nd
         print('padding type is forced to zero padding, because neither refection pad2d or replication pad2d has a deterministic implementation')
 
     # infer number of input images
-    dir_data_train = dataroot + '/train'
-    fns = os.listdir(dir_data_train)
-    fns = [x for x in fns if x.endswith('.png')]
-    print(f'{len(fns)} images found')
-    img = Image.open(f"{dir_data_train}/{fns[0]}")
-    print(f'image shape:',img.size)
     
-    num_img = img.size[0] / img.size[1]
-    assert int(num_img) == num_img, f'img size {img.size[0]} / {img.size[1]} = {num_img} is not an integer'
-    num_img = int(num_img)
     
-    input_no = num_img - modalities_no - seg_no
-    assert input_no > 0, f'inferred number of input images is {input_no} (modalities_no {modalities_no}, seg_no {seg_no}); should be greater than 0'
+    if dataset_mode == 'unaligned':
+        dir_data_train = dataroot + '/trainA'
+        fns = os.listdir(dir_data_train)
+        fns = [x for x in fns if x.endswith('.png')]
+        print(f'{len(fns)} images found in trainA')
+        img = Image.open(f"{dir_data_train}/{fns[0]}")
+        print(f'image shape:',img.size)
+
+        for i in range(1, modalities_no + 1):
+            dir_data_train = dataroot + f'/trainB{i}'
+            fns = os.listdir(dir_data_train)
+            fns = [x for x in fns if x.endswith('.png')]
+            print(f'{len(fns)} images found in trainB{i}')
+            img = Image.open(f"{dir_data_train}/{fns[0]}")
+            print(f'image shape:',img.size)
+        
+        input_no = 1
+        num_img = None
+        
+        lambda_identity = 0
+        pool_size = 50 # https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/blob/master/scripts/train_cyclegan.sh
+        
+    else:
+        dir_data_train = dataroot + '/train'
+        fns = os.listdir(dir_data_train)
+        fns = [x for x in fns if x.endswith('.png')]
+        print(f'{len(fns)} images found')
+        img = Image.open(f"{dir_data_train}/{fns[0]}")
+        print(f'image shape:',img.size)
+        
+        num_img = img.size[0] / img.size[1]
+        assert int(num_img) == num_img, f'img size {img.size[0]} / {img.size[1]} = {num_img} is not an integer'
+        num_img = int(num_img)
+        
+        input_no = num_img - modalities_no - seg_no
+        assert input_no > 0, f'inferred number of input images is {input_no} (modalities_no {modalities_no}, seg_no {seg_no}); should be greater than 0'
+        
+        pool_size = 0
+        
     d_params['input_no'] = input_no
     d_params['scale_size'] = img.size[1]
     d_params['gpu_ids'] = gpu_ids
+    d_params['lambda_identity'] = 0
+    d_params['pool_size'] = pool_size
+    
     
     # update generator arch
     net_g = net_g.split(',')
@@ -470,7 +508,6 @@ def train(dataroot, name, gpu_ids, checkpoints_dir, input_nc, output_nc, ngf, nd
             epoch, n_epochs + n_epochs_decay, time.time() - epoch_start_time))
         # update learning rates at the end of every epoch.
         model.update_learning_rate()
-
 
 if __name__ == '__main__':
     train()

--- a/tests/test_cli_inference.py
+++ b/tests/test_cli_inference.py
@@ -14,12 +14,12 @@ def match_suffix(l_suffix_cli, model='DeepLIIF'):
     """
     Given a list of suffix found in cli output folder, derive a list of suffix used by testpy output
     """
-    assert model in ['DeepLIIF', 'DeepLIIFExt', 'SDG'], f'Cannot derive suffix of output images for model {model}'
+    assert model in ['DeepLIIF', 'DeepLIIFExt', 'SDG', 'CycleGAN'], f'Cannot derive suffix of output images for model {model}'
     
     if model == 'DeepLIIF':
         d_cli2testpy = {'Hema':'fake_B_1', 'DAPI':'fake_B_2', 'Lap2':'fake_B_3',
                         'Marker':'fake_B_4', 'Seg':'fake_B_5'}
-    elif model in ['DeepLIIFExt', 'SDG']:
+    elif model in ['DeepLIIFExt', 'SDG', 'CycleGAN']:
         d_cli2testpy = {'mod':'fake_B_', 'Seg':'fake_BS_'}
     
     # only include cli suffix that matches the specified mapping

--- a/tests/test_cli_train.py
+++ b/tests/test_cli_train.py
@@ -20,14 +20,14 @@ CMD_BASIC = 'python cli.py train --model {model} --dataroot {dataroot} --name te
 #----------------------
 #---- cpu-based -------
 #----------------------
-def test_cli_train(tmp_path, model_info):
+def test_cli_train(tmp_path, model_info, foldername_suffix):
     torch.cuda.nvtx.range_push("test_cli_train")
     dirs_input = model_info['dir_input_train']
     for i in range(len(dirs_input)):
         torch.cuda.nvtx.range_push(f"test_cli_train {dirs_input[i]}")
         dir_save = tmp_path
         
-        fns_input = [f for f in os.listdir(dirs_input[i] + '/train') if os.path.isfile(os.path.join(dirs_input[i] + '/train', f)) and f.endswith('png')]
+        fns_input = [f for f in os.listdir(dirs_input[i] + '/train' + foldername_suffix) if os.path.isfile(os.path.join(dirs_input[i] + '/train' + foldername_suffix, f)) and f.endswith('png')]
         num_input = len(fns_input)
         assert num_input > 0
         
@@ -44,7 +44,7 @@ def test_cli_train(tmp_path, model_info):
 #----------------------
 #---- gpu: single -----
 #----------------------
-def test_cli_train_single_gpu(tmp_path, model_info):
+def test_cli_train_single_gpu(tmp_path, model_info, foldername_suffix):
     if available_gpus > 0:
         torch.cuda.nvtx.range_push("test_cli_train_single_gpu")
         dirs_input = model_info['dir_input_train']
@@ -52,7 +52,7 @@ def test_cli_train_single_gpu(tmp_path, model_info):
             torch.cuda.nvtx.range_push(f"test_cli_train_single_gpu {dirs_input[i]}")
             dir_save = tmp_path
             
-            fns_input = [f for f in os.listdir(dirs_input[i] + '/train') if os.path.isfile(os.path.join(dirs_input[i] + '/train', f)) and f.endswith('png')]
+            fns_input = [f for f in os.listdir(dirs_input[i] + '/train' + foldername_suffix) if os.path.isfile(os.path.join(dirs_input[i] + '/train' + foldername_suffix, f)) and f.endswith('png')]
             num_input = len(fns_input)
             assert num_input > 0
     
@@ -69,7 +69,7 @@ def test_cli_train_single_gpu(tmp_path, model_info):
         pytest.skip(f'Detected {available_gpus} (< 1) available GPUs. Skip.')
 
 
-def test_cli_train_single_gpu_optimizer(tmp_path, model_info):
+def test_cli_train_single_gpu_optimizer(tmp_path, model_info, foldername_suffix):
     if available_gpus > 0:
         torch.cuda.nvtx.range_push("test_cli_train_single_gpu_optimizer")
         dirs_input = model_info['dir_input_train']
@@ -77,7 +77,7 @@ def test_cli_train_single_gpu_optimizer(tmp_path, model_info):
             torch.cuda.nvtx.range_push(f"test_cli_train_single_gpu {dirs_input[i]}")
             dir_save = tmp_path
             
-            fns_input = [f for f in os.listdir(dirs_input[i] + '/train') if os.path.isfile(os.path.join(dirs_input[i] + '/train', f)) and f.endswith('png')]
+            fns_input = [f for f in os.listdir(dirs_input[i] + '/train' + foldername_suffix) if os.path.isfile(os.path.join(dirs_input[i] + '/train' + foldername_suffix, f)) and f.endswith('png')]
             num_input = len(fns_input)
             assert num_input > 0
     
@@ -94,7 +94,7 @@ def test_cli_train_single_gpu_optimizer(tmp_path, model_info):
         pytest.skip(f'Detected {available_gpus} (< 1) available GPUs. Skip.')
 
 
-def test_cli_train_single_gpu_netg(tmp_path, model_info):
+def test_cli_train_single_gpu_netg(tmp_path, model_info, foldername_suffix):
     if available_gpus > 0:
         torch.cuda.nvtx.range_push("test_cli_train_single_gpu_netg")
         dirs_input = model_info['dir_input_train']
@@ -102,7 +102,7 @@ def test_cli_train_single_gpu_netg(tmp_path, model_info):
             torch.cuda.nvtx.range_push(f"test_cli_train_single_gpu {dirs_input[i]}")
             dir_save = tmp_path
             
-            fns_input = [f for f in os.listdir(dirs_input[i] + '/train') if os.path.isfile(os.path.join(dirs_input[i] + '/train', f)) and f.endswith('png')]
+            fns_input = [f for f in os.listdir(dirs_input[i] + '/train' + foldername_suffix) if os.path.isfile(os.path.join(dirs_input[i] + '/train' + foldername_suffix, f)) and f.endswith('png')]
             num_input = len(fns_input)
             assert num_input > 0
     
@@ -127,7 +127,7 @@ def test_cli_train_single_gpu_netg(tmp_path, model_info):
         pytest.skip(f'Detected {available_gpus} (< 1) available GPUs. Skip.')
         
 
-def test_cli_train_single_gpu_netgs(tmp_path, model_info):
+def test_cli_train_single_gpu_netgs(tmp_path, model_info, foldername_suffix):
     if available_gpus > 0:
         torch.cuda.nvtx.range_push("test_cli_train_single_gpu_netgs")
         dirs_input = model_info['dir_input_train']
@@ -135,7 +135,7 @@ def test_cli_train_single_gpu_netgs(tmp_path, model_info):
             torch.cuda.nvtx.range_push(f"test_cli_train_single_gpu {dirs_input[i]}")
             dir_save = tmp_path
             
-            fns_input = [f for f in os.listdir(dirs_input[i] + '/train') if os.path.isfile(os.path.join(dirs_input[i] + '/train', f)) and f.endswith('png')]
+            fns_input = [f for f in os.listdir(dirs_input[i] + '/train' + foldername_suffix) if os.path.isfile(os.path.join(dirs_input[i] + '/train' + foldername_suffix, f)) and f.endswith('png')]
             num_input = len(fns_input)
             assert num_input > 0
     
@@ -160,7 +160,7 @@ def test_cli_train_single_gpu_netgs(tmp_path, model_info):
         pytest.skip(f'Detected {available_gpus} (< 1) available GPUs. Skip.')
 
 
-def test_cli_train_single_gpu_withval(tmp_path, model_info):
+def test_cli_train_single_gpu_withval(tmp_path, model_info, foldername_suffix):
     if available_gpus > 0:
         torch.cuda.nvtx.range_push("test_cli_train_single_gpu_withval")
         dirs_input = model_info['dir_input_train']
@@ -168,7 +168,7 @@ def test_cli_train_single_gpu_withval(tmp_path, model_info):
             torch.cuda.nvtx.range_push(f"test_cli_train_single_gpu {dirs_input[i]}")
             dir_save = tmp_path
             
-            fns_input = [f for f in os.listdir(dirs_input[i] + '/train') if os.path.isfile(os.path.join(dirs_input[i] + '/train', f)) and f.endswith('png')]
+            fns_input = [f for f in os.listdir(dirs_input[i] + '/train' + foldername_suffix) if os.path.isfile(os.path.join(dirs_input[i] + '/train' + foldername_suffix, f)) and f.endswith('png')]
             num_input = len(fns_input)
             assert num_input > 0
     
@@ -187,7 +187,7 @@ def test_cli_train_single_gpu_withval(tmp_path, model_info):
 #----------------------
 #---- gpu: multi ------
 #----------------------
-def test_cli_train_multi_gpu_dp(tmp_path, model_info):
+def test_cli_train_multi_gpu_dp(tmp_path, model_info, foldername_suffix):
     if available_gpus > 1:
         torch.cuda.nvtx.range_push("test_cli_train_multi_gpu_dp")
         dirs_input = model_info['dir_input_train']
@@ -195,7 +195,7 @@ def test_cli_train_multi_gpu_dp(tmp_path, model_info):
             torch.cuda.nvtx.range_push(f"test_cli_train_multi_gpu_dp {dirs_input[i]}")
             dir_save = tmp_path
             
-            fns_input = [f for f in os.listdir(dirs_input[i] + '/train') if os.path.isfile(os.path.join(dirs_input[i] + '/train', f)) and f.endswith('png')]
+            fns_input = [f for f in os.listdir(dirs_input[i] + '/train' + foldername_suffix) if os.path.isfile(os.path.join(dirs_input[i] + '/train' + foldername_suffix, f)) and f.endswith('png')]
             num_input = len(fns_input)
             assert num_input > 0
             

--- a/tests/test_cli_trainlaunch.py
+++ b/tests/test_cli_trainlaunch.py
@@ -25,7 +25,7 @@ assert res.returncode == 0
 #----------------------
 #---- gpu: single -----
 #----------------------
-def test_cli_trainlaunch_single_gpu(tmp_path, model_info):
+def test_cli_trainlaunch_single_gpu(tmp_path, model_info, foldername_suffix):
     if available_gpus > 0:
         torch.cuda.nvtx.range_push("test_cli_trainlaunch_single_gpu")
         dirs_input = model_info['dir_input_train']
@@ -34,7 +34,7 @@ def test_cli_trainlaunch_single_gpu(tmp_path, model_info):
             torch.cuda.nvtx.range_push(f"test_cli_trainlaunch_single_gpu {dirs_input[i]}")
             dir_save = tmp_path
             
-            fns_input = [f for f in os.listdir(dirs_input[i] + '/train') if os.path.isfile(os.path.join(dirs_input[i] + '/train', f)) and f.endswith('png')]
+            fns_input = [f for f in os.listdir(dirs_input[i] + '/train' + foldername_suffix) if os.path.isfile(os.path.join(dirs_input[i] + '/train' + foldername_suffix, f)) and f.endswith('png')]
             num_input = len(fns_input)
             assert num_input > 0
     
@@ -52,7 +52,7 @@ def test_cli_trainlaunch_single_gpu(tmp_path, model_info):
         pytest.skip(f'Detected {available_gpus} (< 1) available GPUs. Skip.')
 
 
-def test_cli_trainlaunch_single_gpu_optimizer(tmp_path, model_info):
+def test_cli_trainlaunch_single_gpu_optimizer(tmp_path, model_info, foldername_suffix):
     if available_gpus > 0:
         torch.cuda.nvtx.range_push("test_cli_trainlaunch_single_gpu_optimizer")
         dirs_input = model_info['dir_input_train']
@@ -60,7 +60,8 @@ def test_cli_trainlaunch_single_gpu_optimizer(tmp_path, model_info):
             torch.cuda.nvtx.range_push(f"test_cli_trainlaunch_single_gpu {dirs_input[i]}")
             dir_save = tmp_path
             
-            fns_input = [f for f in os.listdir(dirs_input[i] + '/train') if os.path.isfile(os.path.join(dirs_input[i] + '/train', f)) and f.endswith('png')]
+            
+            fns_input = [f for f in os.listdir(dirs_input[i] + '/train' + foldername_suffix) if os.path.isfile(os.path.join(dirs_input[i] + '/train' + foldername_suffix, f)) and f.endswith('png')]
             num_input = len(fns_input)
             assert num_input > 0
     
@@ -78,7 +79,7 @@ def test_cli_trainlaunch_single_gpu_optimizer(tmp_path, model_info):
         pytest.skip(f'Detected {available_gpus} (< 1) available GPUs. Skip.')
 
 
-def test_cli_trainlaunch_single_gpu_netg(tmp_path, model_info):
+def test_cli_trainlaunch_single_gpu_netg(tmp_path, model_info, foldername_suffix):
     if available_gpus > 0:
         torch.cuda.nvtx.range_push("test_cli_trainlaunch_single_gpu_netg")
         dirs_input = model_info['dir_input_train']
@@ -86,7 +87,7 @@ def test_cli_trainlaunch_single_gpu_netg(tmp_path, model_info):
             torch.cuda.nvtx.range_push(f"test_cli_trainlaunch_single_gpu {dirs_input[i]}")
             dir_save = tmp_path
             
-            fns_input = [f for f in os.listdir(dirs_input[i] + '/train') if os.path.isfile(os.path.join(dirs_input[i] + '/train', f)) and f.endswith('png')]
+            fns_input = [f for f in os.listdir(dirs_input[i] + '/train' + foldername_suffix) if os.path.isfile(os.path.join(dirs_input[i] + '/train' + foldername_suffix, f)) and f.endswith('png')]
             num_input = len(fns_input)
             assert num_input > 0
     
@@ -113,7 +114,7 @@ def test_cli_trainlaunch_single_gpu_netg(tmp_path, model_info):
         pytest.skip(f'Detected {available_gpus} (< 1) available GPUs. Skip.')
         
 
-def test_cli_trainlaunch_single_gpu_netgs(tmp_path, model_info):
+def test_cli_trainlaunch_single_gpu_netgs(tmp_path, model_info, foldername_suffix):
     if available_gpus > 0:
         torch.cuda.nvtx.range_push("test_cli_trainlaunch_single_gpu_netgs")
         dirs_input = model_info['dir_input_train']
@@ -121,7 +122,7 @@ def test_cli_trainlaunch_single_gpu_netgs(tmp_path, model_info):
             torch.cuda.nvtx.range_push(f"test_cli_trainlaunch_single_gpu {dirs_input[i]}")
             dir_save = tmp_path
             
-            fns_input = [f for f in os.listdir(dirs_input[i] + '/train') if os.path.isfile(os.path.join(dirs_input[i] + '/train', f)) and f.endswith('png')]
+            fns_input = [f for f in os.listdir(dirs_input[i] + '/train' + foldername_suffix) if os.path.isfile(os.path.join(dirs_input[i] + '/train' + foldername_suffix, f)) and f.endswith('png')]
             num_input = len(fns_input)
             assert num_input > 0
     
@@ -148,7 +149,7 @@ def test_cli_trainlaunch_single_gpu_netgs(tmp_path, model_info):
         pytest.skip(f'Detected {available_gpus} (< 1) available GPUs. Skip.')
 
 
-def test_cli_trainlaunch_single_gpu_withval(tmp_path, model_info):
+def test_cli_trainlaunch_single_gpu_withval(tmp_path, model_info, foldername_suffix):
     if available_gpus > 0:
         torch.cuda.nvtx.range_push("test_cli_trainlaunch_single_gpu_withval")
         dirs_input = model_info['dir_input_train']
@@ -156,7 +157,7 @@ def test_cli_trainlaunch_single_gpu_withval(tmp_path, model_info):
             torch.cuda.nvtx.range_push(f"test_cli_trainlaunch_single_gpu {dirs_input[i]}")
             dir_save = tmp_path
             
-            fns_input = [f for f in os.listdir(dirs_input[i] + '/train') if os.path.isfile(os.path.join(dirs_input[i] + '/train', f)) and f.endswith('png')]
+            fns_input = [f for f in os.listdir(dirs_input[i] + '/train' + foldername_suffix) if os.path.isfile(os.path.join(dirs_input[i] + '/train' + foldername_suffix, f)) and f.endswith('png')]
             num_input = len(fns_input)
             assert num_input > 0
     
@@ -176,7 +177,7 @@ def test_cli_trainlaunch_single_gpu_withval(tmp_path, model_info):
 #----------------------
 #---- gpu: multi ------
 #----------------------
-def test_cli_trainlaunch_multi_gpu_dp(tmp_path, model_info):
+def test_cli_trainlaunch_multi_gpu_dp(tmp_path, model_info, foldername_suffix):
     if available_gpus > 1:
         torch.cuda.nvtx.range_push("test_cli_trainlaunch_multi_gpu_dp")
         dirs_input = model_info['dir_input_train']
@@ -184,7 +185,7 @@ def test_cli_trainlaunch_multi_gpu_dp(tmp_path, model_info):
             torch.cuda.nvtx.range_push(f"test_cli_trainlaunch_multi_gpu_dp {dirs_input[i]}")
             dir_save = tmp_path
             
-            fns_input = [f for f in os.listdir(dirs_input[i] + '/train') if os.path.isfile(os.path.join(dirs_input[i] + '/train', f)) and f.endswith('png')]
+            fns_input = [f for f in os.listdir(dirs_input[i] + '/train' + foldername_suffix) if os.path.isfile(os.path.join(dirs_input[i] + '/train' + foldername_suffix, f)) and f.endswith('png')]
             num_input = len(fns_input)
             assert num_input > 0
             


### PR DESCRIPTION
This PR mainly consists of the newly implemented model class `CycleGAN` to be used for unpaired image generation, i.e., when there is no registered pairs of source modality and target modalitie(s).

Main code changes:
- `deepliif/models/CycleGAN.py`: model class definition
- `deepliif/data/unaligned_dataset.py`: corresponding dataset class used for unpaired image generation problems
- `cli.py train`, `cli.py trainlaunch`, `train.py`, `deepliif/scripts/train.py`: training method updated to be compatible with the new model class
- `deepliif/models/__init__.py` & `cli.py test`: inference method updated to be compatible with the new model class
- `conftest.py` & `tests/*`: tests updated to be compatible with the new model class (mainly how to infer the foldername in test data)
- training arguments in `cli.py` and the corresponding support in `deepliif/models/networks.py`
  - new argument `upsample`: upsample layer (convtranspose (default), resize_conv, and pixel shuffle)
  - new argument `label-smoothing`: smooth the ground truth values to prevent the discriminators from behaving too confidently
  - deprecated `lr`, new arguments `lr-g` and `lr-d`: allow to use different learning rate for generators and discriminators
 
Other minor changes:
- test arguments in `cli.py`:
  - new argument `filename-pattern`: use glob to match the pattern against all available filenames in the input folder which enables inference on a smaller subset of images when needed
  - new argument `epoch`: allow to run inference using models at a specified epoch number (of course there needs to be a matched checkpoint)
  - new argument `BtoA`: specifically used for unpaired image generation, it instructs the inference function to load models and run inference for a chosen direction; when BtoA is false, the method loads netGAs, otherwise netGBs
    - note that this is different from argument `direction` in training which takes value of AtoB or BtoA: `direction` refers to how to understand the order of the data (data-level), while the argument `BtoA` in inference refers to what models to load (model-level)
- hardcoded `Image.MAX_IMAGE_PIXELS = None` to allow processing large (typically WSI) images
- corresponding updates in other model classes to use the new training arguments such as `lr-g`
